### PR TITLE
fix: add missing content_posts.image_url column

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -307,4 +307,5 @@ function migrate(db: Database.Database) {
 
   // Column migrations (safe to re-run)
   try { db.exec("ALTER TABLE leads ADD COLUMN pause_outreach INTEGER DEFAULT 0"); } catch { /* column exists */ }
+  try { db.exec("ALTER TABLE content_posts ADD COLUMN image_url TEXT"); } catch { /* column exists */ }
 }


### PR DESCRIPTION
Fixes #2

## Root cause
`GET /api/approvals` throws `SqliteError: no such column: image_url` (500) whenever there is pending content. The `content_posts` table definition in `migrate()` (`src/lib/db.ts`) never included an `image_url` column, yet `src/app/api/approvals/route.ts` selects `content_posts.image_url` and `src/app/api/content-item/route.ts` reads/writes it. No `ALTER TABLE` migration was ever added for it.

## Fix
Add an idempotent column migration in the "Column migrations (safe to re-run)" section of `migrate()`, matching the existing pattern used for `leads.pause_outreach`:

```ts
try { db.exec("ALTER TABLE content_posts ADD COLUMN image_url TEXT"); } catch { /* column exists */ }
```

This ensures the column exists on both fresh and existing databases without erroring on repeated runs.

## Testing
- `npx tsc --noEmit` passes with no new errors.