### PR TITLE
fix: create missing content_queue_items table

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -303,6 +303,23 @@ function migrate(db: Database.Database) {
     );
     CREATE INDEX IF NOT EXISTS idx_brand_digests_brand ON brand_digests(brand_id);
 
+    CREATE TABLE IF NOT EXISTS content_queue_items (
+      id TEXT PRIMARY KEY,
+      platform TEXT NOT NULL,
+      format TEXT NOT NULL,
+      pillar INTEGER,
+      text_preview TEXT,
+      full_content TEXT,
+      image_url TEXT,
+      status TEXT NOT NULL DEFAULT 'draft',
+      scheduled_for DATETIME,
+      queue_json TEXT,
+      source TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE INDEX IF NOT EXISTS idx_content_queue_items_status ON content_queue_items(status);
+
   `);
 
   // Column migrations (safe to re-run)


### PR DESCRIPTION
Fixes #3

Root cause: `src/app/api/content-item/route.ts` queries and inserts into a `content_queue_items` table (GET and PATCH handlers), but that table was never created by `migrate()` in `src/lib/db.ts` (or anywhere else in `src/` or `scripts/`), so every call crashed with `SqliteError: no such table: content_queue_items`.

Fix: add a `CREATE TABLE IF NOT EXISTS content_queue_items (...)` to `migrate()` in `src/lib/db.ts`, matching the exact columns used in the route's INSERT statement (`id, platform, format, pillar, text_preview, full_content, image_url, status, scheduled_for, queue_json, source, updated_at`), plus a `created_at` column for consistency with the other tables in this schema. `id` is `TEXT PRIMARY KEY` to match how the route uses it, and an index on `status` was added since that's a natural filter/list dimension for a content queue (matching the pattern already used for `content_posts.status`).

Verified with `npx tsc --noEmit` — no new type errors introduced.