### PR TITLE
fix: move /agents redirect to config-level to avoid performance.measure crash

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,15 @@ const nextConfig: NextConfig = {
   // Prevent Next.js from inferring a parent workspace root from monorepo traversal, which
   // changes the standalone output path layout and breaks systemd start paths.
   outputFileTracingRoot: path.join(__dirname),
+  async redirects() {
+    return [
+      {
+        source: '/agents',
+        destination: '/agents/squads',
+        permanent: false,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function AgentsPage() {
-  redirect('/agents/squads');
-}


### PR DESCRIPTION
Fixes #6

## Root cause

`/agents` throws an uncaught page error:

```
Failed to execute 'measure' on 'Performance': ''AgentsPage' cannot have a negative time stamp.
```

There is no application code that calls `performance.mark`/`performance.measure` anywhere in `src/`. The mark name `AgentsPage` is generated internally by Next.js App Router's own React Server Components navigation-timing instrumentation. `src/app/agents/page.tsx` was a page component that did nothing but call `redirect('/agents/squads')` synchronously during render — a route shape (component mounts, renders nothing, immediately redirects) that appears to trigger a zero/negative-duration measurement in Next's internal instrumentation for this route.

## Fix

- Added an `async redirects()` entry to `next.config.ts`: `{ source: '/agents', destination: '/agents/squads', permanent: false }`.
- Deleted `src/app/agents/page.tsx`.

With a config-level redirect, Next.js resolves and serves the redirect before any route component is mounted, so no `AgentsPage` component (and therefore no instrumentation mark for it) is ever created. The user-visible behavior is unchanged: `GET /agents` still results in `/agents/squads`.

There is no `layout.tsx` under `src/app/agents/`, so nothing is left orphaned by removing `page.tsx`; the sibling routes (`/agents/comms`, `/agents/workspace`, `/agents/squads`) are untouched.

## Verification

- `npx tsc --noEmit` passes with no errors.