### PR TITLE
fix: eliminate duplicate React keys on /automations

### DIFF
--- a/src/app/automations/page.tsx
+++ b/src/app/automations/page.tsx
@@ -242,12 +242,12 @@ export default function AutomationsPage() {
               <p className="text-sm text-muted-foreground text-center py-8">No execution data yet</p>
             ) : (
               <div className="space-y-2">
-                {skill_executions.map(exec => {
+                {skill_executions.map((exec, execIndex) => {
                   const maxCount = Math.max(...skill_executions.map(e => e.count), 1);
                   const width = (exec.count / maxCount) * 100;
                   const style = agentStyles[exec.agent] ?? fallbackStyle;
                   return (
-                    <div key={`${exec.agent}-${exec.skill}`} className="space-y-1">
+                    <div key={`${exec.agent}-${exec.skill}-${execIndex}`} className="space-y-1">
                       <div className="flex items-center justify-between text-xs">
                         <div className="flex items-center gap-2">
                           <span className={`w-1.5 h-1.5 rounded-full ${style.dotClass}`} />


### PR DESCRIPTION
Fixes #5

## Root cause

On `/automations`, the "Skill Executions (30 days)" list is keyed as:

```tsx
key={`${exec.agent}-${exec.skill}`}
```

`skill_executions` is built server-side (`src/app/api/automations/route.ts`) by grouping `activity_log` rows by their raw `action` string, then mapping each distinct action through `ACTION_TO_AGENT` (`src/lib/agent-config.ts`) to get an `{ agent, skill }` pair. Several different actions intentionally map to the *same* agent/skill pair — e.g. both `discover` and `send` map to `{ agent: 'apollo', skill: 'cold-outreach' }`. Since the grouping happens on `action`, not on the resulting `agent`+`skill`, this yields two separate rows in `skill_executions` with identical `agent` and `skill` values (and different counts/last_run), which produced two `<div>` siblings sharing the same key -- triggering React's "Encountered two children with the same key" warning and risking dropped/duplicated rows on re-render.

The seed data (`scripts/seed.ts`) reproduces this in practice: it logs both `discover` and `send` actions within the 30-day window, so this collision occurs with the app's own sample data, not just a hypothetical edge case.

The other `.map()` keys on the page were checked and are not affected:
- `key={job.id}` -- one row per schedule entry, ids are per-job.
- `key={agent}` -- iterates `orderedAgentIds`, which is built from a `Set` and is already de-duplicated.
- `key={item.id}` -- one row per approval, ids are per-approval.
- `key={hour}` -- iterates a fixed `0..23` range.

## Fix

Disambiguate the skill-execution key with the row's index in the array, since there's no execution/log id on `SkillExecution` to use instead:

```tsx
{skill_executions.map((exec, execIndex) => {
  ...
  return (
    <div key={`${exec.agent}-${exec.skill}-${execIndex}`} className="space-y-1">
```

This keeps the key stable and unique per render without changing any rendered content.

## Verification

- `npx tsc --noEmit` passes with no new errors.
- Manually traced the data path from `scripts/seed.ts` → `activity_log` → `ACTION_TO_AGENT` → `skill_executions` to confirm the collision is real, not just theoretical.