### PR TITLE
fix: create missing llm_usage_events table

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -303,6 +303,18 @@ function migrate(db: Database.Database) {
     );
     CREATE INDEX IF NOT EXISTS idx_brand_digests_brand ON brand_digests(brand_id);
 
+    CREATE TABLE IF NOT EXISTS llm_usage_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      day TEXT,
+      agent_id TEXT,
+      model TEXT,
+      total_tokens INTEGER,
+      cost_usd REAL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE INDEX IF NOT EXISTS idx_llm_usage_events_day ON llm_usage_events(day);
+    CREATE INDEX IF NOT EXISTS idx_llm_usage_events_day_agent ON llm_usage_events(day, agent_id);
+
   `);
 
   // Column migrations (safe to re-run)


### PR DESCRIPTION
Fixes #1

## Root cause
`GET /api/usage` (`src/app/api/usage/route.ts`) queries a table `llm_usage_events` with columns `day`, `agent_id`, `model`, `total_tokens`, `cost_usd`, but `src/lib/db.ts` never created this table in its `migrate()` function. On any fresh or seeded DB this makes the route throw `SqliteError: no such table: llm_usage_events` and return a 500.

## Fix
Added a `CREATE TABLE IF NOT EXISTS llm_usage_events (...)` statement to the same `db.exec` migration block in `src/lib/db.ts`, following the existing style (autoincrement id, `created_at DATETIME DEFAULT CURRENT_TIMESTAMP`, matching event-style tables like `activity_log`). Columns match exactly what the route selects: `day TEXT`, `agent_id TEXT`, `model TEXT`, `total_tokens INTEGER`, `cost_usd REAL`. Also added indexes on `(day)` and `(day, agent_id)` to match the route's `WHERE day >= ...` / `GROUP BY day` / `GROUP BY agent_id` query patterns.

## Note
Nothing in the repo currently writes to `llm_usage_events` — it's expected to be populated by an external process. This fix only stops the read route from crashing on a fresh/seeded DB; the endpoint will simply return zeroed/empty aggregates until rows are inserted.

## Verification
`npx tsc --noEmit` passes cleanly with no new errors introduced by this change.