### PR TITLE
fix: prevent Recharts zero/negative dimension warnings on dashboard home

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -527,7 +527,11 @@ function MetricColumn({
       </div>
       {sparkline && sparkline.length > 1 && (
         <div className="h-10 mt-3">
-          <ResponsiveContainer width="100%" height="100%">
+          {/* Fixed pixel height (matches h-10) instead of "100%" so Recharts has a
+              real, non-percentage size to measure on first mount -- a percentage
+              height resolves to the ResponsiveContainer's -1 initial dimension
+              before ResizeObserver fires, which triggers its zero-size warning. */}
+          <ResponsiveContainer width="100%" height={40}>
             <AreaChart data={sparkline}>
               <defs>
                 <linearGradient id={`gradient-${label}`} x1="0" y1="0" x2="0" y2="1">

--- a/src/components/ui/stat-card.tsx
+++ b/src/components/ui/stat-card.tsx
@@ -35,7 +35,11 @@ export function StatCard({ label, value, icon: Icon, trend, sparkline, color = '
       </div>
       {sparkline && sparkline.length > 1 && (
         <div className="h-14 mt-5">
-          <ResponsiveContainer width="100%" height="100%">
+          {/* Fixed pixel height (matches h-14) instead of "100%" so Recharts has a
+              real, non-percentage size to measure on first mount -- a percentage
+              height resolves to the ResponsiveContainer's -1 initial dimension
+              before ResizeObserver fires, which triggers its zero-size warning. */}
+          <ResponsiveContainer width="100%" height={56}>
             <AreaChart data={sparkline}>
               <defs>
                 <linearGradient id={`gradient-${label}`} x1="0" y1="0" x2="0" y2="1">


### PR DESCRIPTION
Fixes #4

## Root cause

`MetricColumn` (in `src/app/page.tsx`, rendered 4x on the dashboard
home page) and `StatCard` (`src/components/ui/stat-card.tsx`) each
wrap a sparkline in:

```tsx
<ResponsiveContainer width="100%" height="100%">
```

Recharts' `ResponsiveContainer` initializes its internal size state
to `{ width: -1, height: -1 }` and only measures the real DOM size
inside a `useEffect` that fires after the first paint (via
`getBoundingClientRect` + `ResizeObserver`). When `height` is a
percentage string, the calculated height used for the very first
render falls back to that `-1` initial value, which trips Recharts'
own `"The width(...) and height(...) of chart should be greater than
0..."` console warning on every mount -- independent of whether the
surrounding flex/grid parent has actually settled its layout yet.
With 4 `MetricColumn` sparklines on `/`, this produced the repeated
warning noise reported in the issue.

`TrendChart` and `BarBreakdown` were checked too, but they already
pass a fixed numeric `height` (e.g. `height={260}`) to
`ResponsiveContainer` rather than a percentage, so they were not
affected.

## Fix

Both offending wrapper `div`s already have a fixed Tailwind height
(`h-14` = 56px for `StatCard`, `h-10` = 40px for `MetricColumn`), so
`ResponsiveContainer` is given that same concrete pixel value as its
`height` prop instead of `"100%"`. Width stays responsive (`"100%"`).
This gives Recharts a real, positive height on the very first render,
so the warning no longer fires -- the underlying layout-timing issue
is fixed, not just silenced.

## Testing

- `npx tsc --noEmit` passes with no new errors.
- Manually reasoned through Recharts' `ResponsiveContainer` /
  `calculateChartDimensions` source (`node_modules/recharts/es6/component/{ResponsiveContainer,responsiveContainerUtils}.js`)
  to confirm a non-percentage, positive `height` prop always satisfies
  the warning's `calculatedHeight > 0` check on first render.