### PR TITLE
fix: harden Brand APIs against a missing/unseeded default brand

### DIFF
--- a/src/app/api/brand/[brandId]/route.ts
+++ b/src/app/api/brand/[brandId]/route.ts
@@ -15,6 +15,8 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ br
   const auth = requireApiUser(req as Request);
   if (auth) return auth;
   const { brandId } = await params;
+  const existing = getBrand(brandId);
+  if (!existing) return NextResponse.json({ error: 'Brand not found' }, { status: 404 });
   const body = await req.json();
   updateBrand(brandId, { name: body.name, keywords: body.keywords, sources: body.sources });
   const brand = getBrand(brandId);

--- a/src/components/brand/tabs/digests-tab.tsx
+++ b/src/components/brand/tabs/digests-tab.tsx
@@ -5,15 +5,18 @@ import { Sparkles, FileText } from 'lucide-react';
 import { formatDate } from '@/lib/utils';
 import { EmptyState } from '@/components/brand/empty-state';
 import { ErrorBanner } from '@/components/ui/error-banner';
+import { CardSkeletonList } from '@/components/ui/loading-skeleton';
 import type { BrandDigest } from '@/types';
 
 export function DigestsTab({ brandId }: { brandId: string }) {
   const [digests, setDigests] = useState<BrandDigest[]>([]);
   const [active, setActive] = useState<BrandDigest | null>(null);
   const [generating, setGenerating] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   function loadDigests() {
+    setLoading(true);
     setError(null);
     fetch(`/api/brand/${brandId}/digests`)
       .then(r => {
@@ -24,7 +27,8 @@ export function DigestsTab({ brandId }: { brandId: string }) {
         setDigests(Array.isArray(data) ? data : []);
         if (Array.isArray(data) && data.length) setActive(data[0]);
       })
-      .catch(err => setError((err as Error).message));
+      .catch(err => setError((err as Error).message || 'Failed to fetch digests'))
+      .finally(() => setLoading(false));
   }
 
   useEffect(() => {
@@ -44,6 +48,15 @@ export function DigestsTab({ brandId }: { brandId: string }) {
     } finally {
       setGenerating(false);
     }
+  }
+
+  if (loading) {
+    return (
+      <div className="grid md:grid-cols-[260px_1fr] gap-4">
+        <CardSkeletonList count={3} />
+        <CardSkeletonList count={1} />
+      </div>
+    );
   }
 
   return (

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { seedChatMessages } from './seed-chat';
 import { getHermesStateDir } from './hermes-state';
+import { DEFAULT_BRAND_ID } from './brand-constants';
 
 const DB_PATH =
   process.env.HERMES_DB_PATH || path.join(getHermesStateDir(), 'hermes.db');
@@ -307,4 +308,12 @@ function migrate(db: Database.Database) {
 
   // Column migrations (safe to re-run)
   try { db.exec("ALTER TABLE leads ADD COLUMN pause_outreach INTEGER DEFAULT 0"); } catch { /* column exists */ }
+
+  // Guarantee the default brand row exists even on a fresh/unseeded DB — brand-scoped
+  // API routes and FK-constrained inserts (brand_mentions, brand_digests, etc.) assume
+  // DEFAULT_BRAND_ID resolves to a real row instead of leaving the Brand module in a
+  // permanent "no brand exists" state.
+  db.prepare(
+    `INSERT OR IGNORE INTO brands (id, name, keywords, sources) VALUES (?, ?, ?, ?)`
+  ).run(DEFAULT_BRAND_ID, 'My Brand', '[]', '[]');
 }


### PR DESCRIPTION
Fixes #16, Fixes #17

## Root cause

Both issues trace back to the same root cause: the Brand module assumed `DEFAULT_BRAND_ID` (`src/lib/brand-constants.ts`) always resolves to a real row in the `brands` table. On a fresh DB where `scripts/seed.ts` was never run, that assumption breaks and several code paths didn't handle it gracefully.

**Already fixed by a prior PR (verified, not re-touched here):** `src/components/brand/brand-header.tsx` already does proper loading/error handling — on a 404 it shows a "Brand not found" panel with Retry + Brand Settings links instead of ever rendering the literal string `"undefined"`. The same commit (`a268002`) also added correct `loading` + `.finally()` handling to `overview-tab.tsx`, `analytics-tab.tsx`, and `mentions-tab.tsx` — I read all three and confirmed each one already ends its loading state on error/404 and renders `ErrorBanner`/`EmptyState` instead of hanging. No changes were needed in those four files.

## What this PR changes

1. **`src/app/api/brand/[brandId]/route.ts`** — the `PATCH` handler called `updateBrand(brandId, ...)` (a no-op `UPDATE` against a nonexistent row — it errors on nothing) and then returned `getBrand(brandId)`, which is `null`, with a `200` status. Brand Settings saves against a missing brand therefore "succeeded" with a silent `null` body. Fixed by checking `getBrand(brandId)` up front and returning `NextResponse.json({ error: 'Brand not found' }, { status: 404 })` before calling `updateBrand`, matching the existing `GET` handler's 404 behavior.

2. **`src/components/brand/tabs/digests-tab.tsx`** — this is the one tab the `a268002` UI/UX pass missed: it had no `loading` state at all (no skeleton, and `loadDigests()` never gated/ended a loading flag), which is inconsistent with the pattern used everywhere else and is the most likely source of issue #17's "stuck on a loading spinner" for the Digests tab. Added a `loading` state that starts `true`, is reset in `.finally()`, and gates a `CardSkeletonList` skeleton — same pattern as `brand-header.tsx`/`overview-tab.tsx`/etc.

3. **`src/lib/db.ts`** — defense in depth: `migrate()` now does `INSERT OR IGNORE INTO brands (id, name, keywords, sources) VALUES (DEFAULT_BRAND_ID, 'My Brand', '[]', '[]')` (mirroring `scripts/seed.ts`'s brand insert), so a fresh dashboard is never left in a "no brand exists" state at all — regardless of whether `seed.ts` was run. This also matters because `foreign_keys = ON` is set on the DB connection and several brand-scoped tables (`brand_mentions`, `brand_digests`, `brand_alerts`, etc.) have `brand_id REFERENCES brands(id)` — without a seeded row, actions like generating a digest or syncing mentions for a nonexistent brand would throw a foreign-key constraint error instead of a clean 404.

## Verification

- `npx tsc --noEmit` — passes cleanly, no new errors.
- Manually ran the app's `migrate()` against a throwaway fresh DB file and confirmed the `brands` table now contains the seeded `DEFAULT_BRAND_ID` row (`My Brand`, empty keywords/sources) instead of being empty.

## Test plan

- [ ] Delete/rename the local `hermes.db` (or point `HERMES_DB_PATH` at a fresh path) without running `scripts/seed.ts`, start the app, and confirm `/brand/{DEFAULT_BRAND_ID}/overview` now shows a real (seeded) brand header instead of "Brand not found" or "undefined".
- [ ] `PATCH /api/brand/some-nonexistent-id` now returns `404 { error: 'Brand not found' }` instead of `200 null`.
- [ ] Open the AI Digests tab for a brand and confirm a skeleton renders briefly instead of a stale/misleading empty state flashing before data loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)