### PR TITLE
feat: add TikTok mention-sync integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,15 @@ GOOGLE_REDIRECT_URI=
 # Optional API version header (yyyyMM)
 # LINKEDIN_VERSION=
 
+# TikTok (Login Kit OAuth2 app credentials, used to mint/refresh access tokens)
+# TIKTOK_CLIENT_KEY=
+# TIKTOK_CLIENT_SECRET=
+# TikTok OAuth2 access + refresh tokens (Display API: owned-account videos/analytics only).
+# Note: TikTok has no public keyword-search API for brand mentions without
+# separate, approved Research API access -- see src/lib/tiktok-api.ts.
+# TIKTOK_ACCESS_TOKEN=
+# TIKTOK_REFRESH_TOKEN=
+
 # Optional 1Password runtime overlay mode for standalone startup:
 # - off: never use 1Password
 # - auto (default): use 1Password when available, otherwise fallback to existing env

--- a/src/app/api/brand/[brandId]/mentions/sync/route.ts
+++ b/src/app/api/brand/[brandId]/mentions/sync/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireApiUser } from '@/lib/api-auth';
 import { getBrand, insertBrandMention } from '@/lib/brand-queries';
 import { searchXMentions } from '@/lib/x-api';
+import { searchTikTokMentions } from '@/lib/tiktok-api';
 import { classifyMention } from '@/lib/mention-classify';
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
@@ -10,9 +11,11 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ bra
   const { brandId } = await params;
 
   const bearerToken = process.env.X_BEARER_TOKEN;
-  if (!bearerToken) {
+  const tiktokAccessToken = process.env.TIKTOK_ACCESS_TOKEN;
+
+  if (!bearerToken && !tiktokAccessToken) {
     return NextResponse.json(
-      { error: 'X_BEARER_TOKEN is not configured. Add it to .env.local to enable live X mention syncing.' },
+      { error: 'No social connector is configured. Add X_BEARER_TOKEN or TIKTOK_ACCESS_TOKEN to .env.local to enable live mention syncing.' },
       { status: 412 },
     );
   }
@@ -21,35 +24,77 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ bra
   if (!brand) return NextResponse.json({ error: 'Brand not found' }, { status: 404 });
   const query = brand.keywords[0] || brand.name;
 
-  try {
-    const results = await searchXMentions({ bearerToken, query, maxResults: 50 });
-    let inserted = 0;
-    for (const r of results) {
-      const { sentiment, emotion } = classifyMention(r.text);
-      insertBrandMention({
-        id: `x_${r.id}`,
-        brand_id: brandId,
-        source_type: 'social',
-        platform: 'x',
-        author_name: r.author_name,
-        author_handle: r.author_handle,
-        author_avatar_url: null,
-        author_reach: r.author_reach,
-        text: r.text,
-        url: r.url || null,
-        likes: r.likes,
-        comments: r.comments,
-        sentiment,
-        emotion,
-        intent: null,
-        is_crisis: false,
-        is_high_impact: r.author_reach > 100_000,
-        published_at: r.published_at,
-      });
-      inserted++;
+  let inserted = 0;
+  const skipped: string[] = [];
+  const errors: Record<string, string> = {};
+
+  if (bearerToken) {
+    try {
+      const results = await searchXMentions({ bearerToken, query, maxResults: 50 });
+      for (const r of results) {
+        const { sentiment, emotion } = classifyMention(r.text);
+        insertBrandMention({
+          id: `x_${r.id}`,
+          brand_id: brandId,
+          source_type: 'social',
+          platform: 'x',
+          author_name: r.author_name,
+          author_handle: r.author_handle,
+          author_avatar_url: null,
+          author_reach: r.author_reach,
+          text: r.text,
+          url: r.url || null,
+          likes: r.likes,
+          comments: r.comments,
+          sentiment,
+          emotion,
+          intent: null,
+          is_crisis: false,
+          is_high_impact: r.author_reach > 100_000,
+          published_at: r.published_at,
+        });
+        inserted++;
+      }
+    } catch (err) {
+      errors.x = (err as Error).message;
     }
-    return NextResponse.json({ synced: inserted });
-  } catch (err) {
-    return NextResponse.json({ error: (err as Error).message }, { status: 502 });
+  } else {
+    skipped.push('x');
   }
+
+  if (tiktokAccessToken) {
+    try {
+      const results = await searchTikTokMentions({ accessToken: tiktokAccessToken, query, maxResults: 50 });
+      for (const r of results) {
+        const { sentiment, emotion } = classifyMention(r.text);
+        insertBrandMention({
+          id: `tiktok_${r.id}`,
+          brand_id: brandId,
+          source_type: 'social',
+          platform: 'tiktok',
+          author_name: r.author_name,
+          author_handle: r.author_handle,
+          author_avatar_url: null,
+          author_reach: r.author_reach,
+          text: r.text,
+          url: r.url || null,
+          likes: r.likes,
+          comments: r.comments,
+          sentiment,
+          emotion,
+          intent: null,
+          is_crisis: false,
+          is_high_impact: r.author_reach > 100_000,
+          published_at: r.published_at,
+        });
+        inserted++;
+      }
+    } catch (err) {
+      errors.tiktok = (err as Error).message;
+    }
+  } else {
+    skipped.push('tiktok');
+  }
+
+  return NextResponse.json({ synced: inserted, skipped, errors });
 }

--- a/src/lib/tiktok-api.ts
+++ b/src/lib/tiktok-api.ts
@@ -1,0 +1,328 @@
+// TikTok integration.
+//
+// IMPORTANT ACCESS-TIER NOTE:
+// TikTok has no open public keyword-search API comparable to X for an
+// unapproved app. There are exactly two real options:
+//
+//   (a) TikTok Display API (Login Kit / "content posting & data" scopes) —
+//       only returns the OWN authorized account's videos + analytics, never
+//       brand-keyword mentions made by other accounts across TikTok. This is
+//       what `fetchOwnVideos` / `fetchOwnVideoAnalytics` below use, and it is
+//       reachable by any registered TikTok developer app.
+//
+//   (b) TikTok Research API — does support broader keyword/hashtag video
+//       search, but requires a separate, strict, approved-researcher access
+//       tier that most teams (and this app, by default) do not have.
+//       `searchTikTokMentions` below is shaped against that endpoint, but
+//       throws a descriptive error rather than returning an empty array when
+//       the configured token/app is not on that tier, so callers (e.g. the
+//       mention-sync route) can surface a clear message instead of silently
+//       reporting zero mentions.
+//
+// In short: this module can authenticate and pull analytics for the brand's
+// own TikTok account, but it CANNOT search TikTok-wide for brand mentions
+// unless/until Research API access is granted.
+
+const TIKTOK_OAUTH_TOKEN_URL = 'https://open.tiktokapis.com/v2/oauth/token/';
+const TIKTOK_VIDEO_LIST_URL = 'https://open.tiktokapis.com/v2/video/list/';
+const TIKTOK_VIDEO_QUERY_URL = 'https://open.tiktokapis.com/v2/video/query/';
+const TIKTOK_RESEARCH_VIDEO_QUERY_URL = 'https://open.tiktokapis.com/v2/research/video/query/';
+
+function num(v: unknown): number {
+  const n = typeof v === 'number' ? v : typeof v === 'string' ? Number(v) : NaN;
+  return Number.isFinite(n) ? n : 0;
+}
+
+// ─── OAuth2 (authorization-code + refresh-token flow, per TikTok Login Kit) ───
+
+export interface TikTokTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  refresh_expires_in: number;
+  open_id: string;
+  scope: string;
+  token_type: string;
+}
+
+interface TikTokOAuthErrorBody {
+  error?: string;
+  error_description?: string;
+  message?: string;
+}
+
+async function postForm(url: string, body: Record<string, string>): Promise<TikTokTokenResponse> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Cache-Control': 'no-cache',
+    },
+    body: new URLSearchParams(body).toString(),
+    cache: 'no-store',
+  });
+  const json = (await res.json().catch(() => ({}))) as TikTokTokenResponse & TikTokOAuthErrorBody;
+  if (!res.ok || json.error) {
+    const detail = json.error_description || json.message || json.error || (await res.text().catch(() => ''));
+    throw new Error(`TikTok OAuth failed (${res.status}): ${detail}`.slice(0, 400));
+  }
+  return json;
+}
+
+/** Step 2 of the authorization-code flow: exchanges the redirect `code` for an access + refresh token. */
+export async function exchangeTikTokAuthCode(opts: {
+  clientKey: string;
+  clientSecret: string;
+  code: string;
+  redirectUri: string;
+}): Promise<TikTokTokenResponse> {
+  return postForm(TIKTOK_OAUTH_TOKEN_URL, {
+    client_key: opts.clientKey,
+    client_secret: opts.clientSecret,
+    code: opts.code,
+    grant_type: 'authorization_code',
+    redirect_uri: opts.redirectUri,
+  });
+}
+
+/** Refreshes an expired/expiring access token using the long-lived refresh token. */
+export async function refreshTikTokToken(opts: {
+  clientKey: string;
+  clientSecret: string;
+  refreshToken: string;
+}): Promise<TikTokTokenResponse> {
+  return postForm(TIKTOK_OAUTH_TOKEN_URL, {
+    client_key: opts.clientKey,
+    client_secret: opts.clientSecret,
+    grant_type: 'refresh_token',
+    refresh_token: opts.refreshToken,
+  });
+}
+
+// ─── Display API: owned-account videos + analytics ────────────────────────
+
+export interface TikTokOwnVideo {
+  id: string;
+  text: string;
+  url: string;
+  author_name: string | null;
+  author_handle: string | null;
+  likes: number;
+  comments: number;
+  shares: number;
+  views: number;
+  published_at: string | null;
+}
+
+interface TikTokVideoListItem {
+  id?: string;
+  video_description?: string;
+  title?: string;
+  share_url?: string;
+  create_time?: number; // unix seconds
+  like_count?: number | string;
+  comment_count?: number | string;
+  share_count?: number | string;
+  view_count?: number | string;
+}
+
+interface TikTokVideoListResponse {
+  data?: {
+    videos?: TikTokVideoListItem[];
+    cursor?: number;
+    has_more?: boolean;
+  };
+  error?: { code?: string; message?: string; log_id?: string };
+}
+
+async function tiktokGet<T>(url: string, accessToken: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    cache: 'no-store',
+  });
+  const json = (await res.json().catch(() => ({}))) as T & { error?: { code?: string; message?: string } };
+  if (!res.ok || (json as { error?: { code?: string } }).error?.code) {
+    const err = (json as { error?: { code?: string; message?: string } }).error;
+    throw new Error(`TikTok API failed (${res.status}): ${err?.code || ''} ${err?.message || ''}`.trim().slice(0, 400));
+  }
+  return json;
+}
+
+/**
+ * Lists videos from the OWN authorized account (Display API — `video.list` scope).
+ * This is NOT a brand-mention search: TikTok's public API does not expose other
+ * accounts' videos by keyword for apps without Research API access.
+ */
+export async function fetchOwnTikTokVideos(opts: {
+  accessToken: string;
+  handle?: string | null;
+  maxResults?: number;
+}): Promise<TikTokOwnVideo[]> {
+  const fields = [
+    'id',
+    'video_description',
+    'title',
+    'share_url',
+    'create_time',
+    'like_count',
+    'comment_count',
+    'share_count',
+    'view_count',
+  ].join(',');
+  const maxCount = Math.min(Math.max(opts.maxResults ?? 20, 1), 20);
+  const params = new URLSearchParams({ fields, max_count: String(maxCount) });
+
+  const res = await tiktokGet<TikTokVideoListResponse>(
+    `${TIKTOK_VIDEO_LIST_URL}?${params.toString()}`,
+    opts.accessToken
+  );
+
+  const videos = res.data?.videos ?? [];
+  return videos.map((v): TikTokOwnVideo => ({
+    id: v.id || crypto.randomUUID(),
+    text: v.video_description || v.title || '',
+    url: v.share_url || '',
+    author_name: null,
+    author_handle: opts.handle ?? null,
+    likes: num(v.like_count),
+    comments: num(v.comment_count),
+    shares: num(v.share_count),
+    views: num(v.view_count),
+    published_at: v.create_time ? new Date(v.create_time * 1000).toISOString() : null,
+  }));
+}
+
+/** Aggregated analytics for the own account's recent videos (sums over the fetched page). */
+export async function fetchOwnTikTokAnalytics(opts: {
+  accessToken: string;
+  handle?: string | null;
+}): Promise<{ videos: number; likes: number; comments: number; shares: number; views: number }> {
+  const videos = await fetchOwnTikTokVideos({ accessToken: opts.accessToken, handle: opts.handle, maxResults: 20 });
+  return videos.reduce(
+    (acc, v) => {
+      acc.videos += 1;
+      acc.likes += v.likes;
+      acc.comments += v.comments;
+      acc.shares += v.shares;
+      acc.views += v.views;
+      return acc;
+    },
+    { videos: 0, likes: 0, comments: 0, shares: 0, views: 0 }
+  );
+}
+
+// ─── Research API: brand-keyword mention search (requires special access tier) ───
+
+export interface TikTokMentionResult {
+  id: string;
+  text: string;
+  url: string;
+  author_name: string | null;
+  author_handle: string | null;
+  author_reach: number;
+  likes: number;
+  comments: number;
+  published_at: string | null;
+}
+
+interface TikTokResearchVideo {
+  id?: string | number;
+  video_description?: string;
+  username?: string;
+  create_time?: number;
+  like_count?: number | string;
+  comment_count?: number | string;
+  share_count?: number | string;
+  view_count?: number | string;
+}
+
+interface TikTokResearchQueryResponse {
+  data?: { videos?: TikTokResearchVideo[]; cursor?: number; has_more?: boolean };
+  error?: { code?: string; message?: string; log_id?: string };
+}
+
+/**
+ * Searches TikTok-wide for videos matching a keyword/hashtag via the
+ * Research API (`/v2/research/video/query/`).
+ *
+ * This endpoint is NOT reachable by a typical app: it requires TikTok's
+ * separate, strict, approved-researcher access tier. If the configured
+ * TIKTOK_ACCESS_TOKEN is not on that tier (the overwhelmingly common case),
+ * TikTok responds with an auth/permission error, and this function throws a
+ * descriptive Error rather than returning an empty array — callers must not
+ * treat a thrown error here as "zero mentions found".
+ */
+export async function searchTikTokMentions(opts: {
+  accessToken: string;
+  query: string;
+  maxResults?: number;
+}): Promise<TikTokMentionResult[]> {
+  const maxCount = Math.min(Math.max(opts.maxResults ?? 50, 10), 100);
+  const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const startDate = oneWeekAgo.toISOString().slice(0, 10).replace(/-/g, '');
+  const endDate = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+
+  const res = await fetch(
+    `${TIKTOK_RESEARCH_VIDEO_QUERY_URL}?fields=id,video_description,username,create_time,like_count,comment_count,share_count,view_count`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${opts.accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: {
+          and: [{ operation: 'IN', field_name: 'keyword', field_values: [opts.query] }],
+        },
+        start_date: startDate,
+        end_date: endDate,
+        max_count: maxCount,
+      }),
+      cache: 'no-store',
+    }
+  );
+
+  if (res.status === 401 || res.status === 403) {
+    throw new Error(
+      'TikTok mention search requires Research API access — the configured TikTok token/app is not on that approved tier. ' +
+      'Use fetchOwnTikTokVideos()/fetchOwnTikTokAnalytics() for the owned-account Display API instead.'
+    );
+  }
+
+  const json = (await res.json().catch(() => ({}))) as TikTokResearchQueryResponse;
+  if (!res.ok || json.error) {
+    const msg = json.error?.message || '';
+    if (/scope|permission|research|access/i.test(msg)) {
+      throw new Error(
+        `TikTok mention search requires Research API access — TikTok rejected the request: ${msg}`.slice(0, 400)
+      );
+    }
+    throw new Error(`TikTok Research API failed (${res.status}): ${msg}`.slice(0, 400));
+  }
+
+  const videos = json.data?.videos ?? [];
+  return videos.map((v): TikTokMentionResult => {
+    const id = String(v.id ?? crypto.randomUUID());
+    const handle = v.username ?? null;
+    return {
+      id,
+      text: v.video_description || '',
+      url: handle ? `https://www.tiktok.com/@${handle}/video/${id}` : '',
+      author_name: null,
+      author_handle: handle,
+      author_reach: 0,
+      likes: num(v.like_count),
+      comments: num(v.comment_count),
+      published_at: v.create_time ? new Date(v.create_time * 1000).toISOString() : null,
+    };
+  });
+}
+
+// Referenced for parity with the Display API's alternate query endpoint name;
+// kept as an export in case callers need the raw URL for diagnostics/logging.
+export const TIKTOK_ENDPOINTS = {
+  oauthToken: TIKTOK_OAUTH_TOKEN_URL,
+  videoList: TIKTOK_VIDEO_LIST_URL,
+  videoQuery: TIKTOK_VIDEO_QUERY_URL,
+  researchVideoQuery: TIKTOK_RESEARCH_VIDEO_QUERY_URL,
+};


### PR DESCRIPTION
Fixes #11

## Root cause
TikTok was listed as a supported platform (`MENTION_PLATFORMS`, `BRAND_SOURCES`, `PlatformBadge`) but had zero real backend integration — all TikTok mention data seen in the app came from `scripts/seed.ts` fabricated demo data. There was no `src/lib/tiktok-api.ts`, and the mentions sync route only ever called `searchXMentions`.

## Important access-tier limitation — please read before expecting parity with X
TikTok does **not** have an open public keyword-search API comparable to X's for an unapproved app. There are exactly two real options:

- **TikTok Display API** (Login Kit OAuth2 scopes) — only returns the **OWN authorized account's** videos and analytics. It cannot search TikTok-wide for brand mentions made by other accounts.
- **TikTok Research API** — does support keyword/hashtag video search, but requires a separate, strict, **approved-researcher access tier** that most teams (and this app, by default) do not have.

This PR builds honestly to that constraint:

- `fetchOwnTikTokVideos` / `fetchOwnTikTokAnalytics` — real, usable Display API calls against the brand's own connected TikTok account (video list + likes/comments/shares/views).
- `exchangeTikTokAuthCode` / `refreshTikTokToken` — OAuth2 authorization-code and refresh-token flow per TikTok Login Kit, using `TIKTOK_CLIENT_KEY` / `TIKTOK_CLIENT_SECRET` / `TIKTOK_ACCESS_TOKEN` / `TIKTOK_REFRESH_TOKEN`.
- `searchTikTokMentions` — implemented against the Research API's `/v2/research/video/query/` endpoint shape, but if the configured token/app is not on the approved research tier (the common case), it **throws a descriptive error** ("TikTok mention search requires Research API access…") rather than silently returning an empty array, so it doesn't masquerade as "zero mentions found."

**In short: without a TikTok Research API grant, this integration can authenticate and report on the brand's own TikTok account, but it cannot discover brand-keyword mentions made by other accounts across TikTok.** That gap is inherent to TikTok's public API surface, not a shortcut taken in this PR.

## Sync route changes
`src/app/api/brand/[brandId]/mentions/sync/route.ts` previously hard-failed with a 412 if `X_BEARER_TOKEN` was missing, and only ever synced X. Since a second platform now exists, the route syncs each configured platform independently and best-effort:

- Each platform (`x`, `tiktok`) is wrapped in its own try/catch — one platform's failure (e.g. TikTok's Research API error above) no longer aborts the other.
- TikTok mentions are inserted with a `tiktok_${id}` mention id so they never collide with X's `x_${id}` ids.
- The response now returns `{ synced, skipped, errors }` — `skipped` lists platforms with no env var configured, `errors` maps platform → error message for platforms that were configured but failed at sync time.
- The route only returns 412 when **no** platform at all is configured, preserving the existing X-only behavior when TikTok env vars are absent.

This diff to the sync route is kept intentionally small/additive since other in-flight PRs may also touch this file.

## Env vars
Documented in `.env.example` under "Social native connectors (optional)": `TIKTOK_CLIENT_KEY`, `TIKTOK_CLIENT_SECRET`, `TIKTOK_ACCESS_TOKEN`, `TIKTOK_REFRESH_TOKEN`.

## Testing
- `npx tsc --noEmit` passes with no new errors.