### PR TITLE
feat: add Reddit mention-sync integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,12 @@ GOOGLE_REDIRECT_URI=
 # LINKEDIN_ORGANIZATION_URN=urn:li:organization:123
 # Optional API version header (yyyyMM)
 # LINKEDIN_VERSION=
+# Reddit script-app credentials (from https://www.reddit.com/prefs/apps) for
+# OAuth client-credentials mention search
+# REDDIT_CLIENT_ID=
+# REDDIT_CLIENT_SECRET=
+# Required descriptive User-Agent (Reddit throttles/blocks generic ones), e.g. "buzzbox/1.0 (by /u/yourname)"
+# REDDIT_USER_AGENT=
 
 # Optional 1Password runtime overlay mode for standalone startup:
 # - off: never use 1Password

--- a/src/app/api/brand/[brandId]/mentions/sync/route.ts
+++ b/src/app/api/brand/[brandId]/mentions/sync/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireApiUser } from '@/lib/api-auth';
 import { getBrand, insertBrandMention } from '@/lib/brand-queries';
 import { searchXMentions } from '@/lib/x-api';
+import { searchRedditMentions } from '@/lib/reddit-api';
 import { classifyMention } from '@/lib/mention-classify';
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
@@ -10,9 +11,14 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ bra
   const { brandId } = await params;
 
   const bearerToken = process.env.X_BEARER_TOKEN;
-  if (!bearerToken) {
+  const redditClientId = process.env.REDDIT_CLIENT_ID;
+  const redditClientSecret = process.env.REDDIT_CLIENT_SECRET;
+  const redditUserAgent = process.env.REDDIT_USER_AGENT;
+  const redditConfigured = !!(redditClientId && redditClientSecret && redditUserAgent);
+
+  if (!bearerToken && !redditConfigured) {
     return NextResponse.json(
-      { error: 'X_BEARER_TOKEN is not configured. Add it to .env.local to enable live X mention syncing.' },
+      { error: 'No social platform is configured. Add X_BEARER_TOKEN or REDDIT_CLIENT_ID/REDDIT_CLIENT_SECRET/REDDIT_USER_AGENT to .env.local to enable live mention syncing.' },
       { status: 412 },
     );
   }
@@ -21,35 +27,83 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ bra
   if (!brand) return NextResponse.json({ error: 'Brand not found' }, { status: 404 });
   const query = brand.keywords[0] || brand.name;
 
-  try {
-    const results = await searchXMentions({ bearerToken, query, maxResults: 50 });
-    let inserted = 0;
-    for (const r of results) {
-      const { sentiment, emotion } = classifyMention(r.text);
-      insertBrandMention({
-        id: `x_${r.id}`,
-        brand_id: brandId,
-        source_type: 'social',
-        platform: 'x',
-        author_name: r.author_name,
-        author_handle: r.author_handle,
-        author_avatar_url: null,
-        author_reach: r.author_reach,
-        text: r.text,
-        url: r.url || null,
-        likes: r.likes,
-        comments: r.comments,
-        sentiment,
-        emotion,
-        intent: null,
-        is_crisis: false,
-        is_high_impact: r.author_reach > 100_000,
-        published_at: r.published_at,
-      });
-      inserted++;
+  let inserted = 0;
+  const skipped: string[] = [];
+  const errors: Record<string, string> = {};
+
+  if (bearerToken) {
+    try {
+      const results = await searchXMentions({ bearerToken, query, maxResults: 50 });
+      for (const r of results) {
+        const { sentiment, emotion } = classifyMention(r.text);
+        insertBrandMention({
+          id: `x_${r.id}`,
+          brand_id: brandId,
+          source_type: 'social',
+          platform: 'x',
+          author_name: r.author_name,
+          author_handle: r.author_handle,
+          author_avatar_url: null,
+          author_reach: r.author_reach,
+          text: r.text,
+          url: r.url || null,
+          likes: r.likes,
+          comments: r.comments,
+          sentiment,
+          emotion,
+          intent: null,
+          is_crisis: false,
+          is_high_impact: r.author_reach > 100_000,
+          published_at: r.published_at,
+        });
+        inserted++;
+      }
+    } catch (err) {
+      errors.x = (err as Error).message;
     }
-    return NextResponse.json({ synced: inserted });
-  } catch (err) {
-    return NextResponse.json({ error: (err as Error).message }, { status: 502 });
+  } else {
+    skipped.push('x');
   }
+
+  if (redditConfigured) {
+    try {
+      const results = await searchRedditMentions({
+        clientId: redditClientId as string,
+        clientSecret: redditClientSecret as string,
+        userAgent: redditUserAgent as string,
+        query,
+        maxResults: 50,
+      });
+      for (const r of results) {
+        const { sentiment, emotion } = classifyMention(r.text);
+        insertBrandMention({
+          id: `reddit_${r.id}`,
+          brand_id: brandId,
+          source_type: 'social',
+          platform: 'reddit',
+          author_name: r.author_name,
+          author_handle: r.author_handle,
+          author_avatar_url: null,
+          author_reach: r.author_reach,
+          text: r.text,
+          url: r.url || null,
+          likes: r.likes,
+          comments: r.comments,
+          sentiment,
+          emotion,
+          intent: null,
+          is_crisis: false,
+          is_high_impact: r.author_reach > 100_000,
+          published_at: r.published_at,
+        });
+        inserted++;
+      }
+    } catch (err) {
+      errors.reddit = (err as Error).message;
+    }
+  } else {
+    skipped.push('reddit');
+  }
+
+  return NextResponse.json({ synced: inserted, skipped, ...(Object.keys(errors).length ? { errors } : {}) });
 }

--- a/src/lib/reddit-api.ts
+++ b/src/lib/reddit-api.ts
@@ -1,0 +1,156 @@
+// Reddit mention search via Reddit's OAuth API.
+//
+// Reddit's "script" app type uses the OAuth2 client-credentials grant, which
+// needs no user-facing consent flow (unlike Meta/TikTok's user-authorization
+// flows) -- just a client id + secret registered at https://www.reddit.com/prefs/apps.
+//
+// Reddit requires a descriptive User-Agent on every request (including the
+// token request) or it will throttle/block the caller with 429s.
+
+export interface RedditMentionResult {
+  id: string;
+  text: string;
+  url: string;
+  author_name: string | null;
+  author_handle: string | null;
+  author_reach: number;
+  likes: number;
+  comments: number;
+  published_at: string | null;
+}
+
+interface RedditTokenResponse {
+  access_token?: string;
+  expires_in?: number;
+  token_type?: string;
+}
+
+interface RedditPostData {
+  id?: string;
+  title?: string;
+  selftext?: string;
+  author?: string;
+  permalink?: string;
+  ups?: number | string;
+  num_comments?: number | string;
+  created_utc?: number | string;
+  subreddit_subscribers?: number | string;
+}
+
+interface RedditListingChild {
+  kind?: string;
+  data?: RedditPostData;
+}
+
+interface RedditSearchResponse {
+  data?: {
+    children?: RedditListingChild[];
+  };
+}
+
+function num(v: unknown): number {
+  const n = typeof v === "number" ? v : typeof v === "string" ? Number(v) : NaN;
+  return Number.isFinite(n) ? n : 0;
+}
+
+// In-memory token cache -- refetched once expired (client-credentials tokens
+// are typically valid for 1 hour). Not persisted across process restarts.
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+async function getRedditAccessToken(opts: {
+  clientId: string;
+  clientSecret: string;
+  userAgent: string;
+}): Promise<string> {
+  const now = Date.now();
+  if (cachedToken && cachedToken.expiresAt > now) {
+    return cachedToken.token;
+  }
+
+  const basicAuth = Buffer.from(`${opts.clientId}:${opts.clientSecret}`).toString("base64");
+  const res = await fetch("https://www.reddit.com/api/v1/access_token", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${basicAuth}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": opts.userAgent,
+    },
+    body: "grant_type=client_credentials",
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Reddit OAuth token request failed (${res.status}): ${text.slice(0, 300)}`);
+  }
+
+  const data = (await res.json()) as RedditTokenResponse;
+  if (!data.access_token) {
+    throw new Error("Reddit OAuth token response missing access_token");
+  }
+
+  const expiresInMs = (num(data.expires_in) || 3600) * 1000;
+  cachedToken = {
+    token: data.access_token,
+    // refresh a little early so we never fire a request on the edge of expiry
+    expiresAt: now + expiresInMs - 60_000,
+  };
+
+  return cachedToken.token;
+}
+
+/** Searches public Reddit posts matching `query` (e.g. a brand keyword) using a script-app (client-credentials) OAuth token. */
+export async function searchRedditMentions(opts: {
+  clientId: string;
+  clientSecret: string;
+  userAgent: string;
+  query: string;
+  maxResults?: number;
+}): Promise<RedditMentionResult[]> {
+  const accessToken = await getRedditAccessToken(opts);
+
+  const params = new URLSearchParams({
+    q: opts.query,
+    sort: "new",
+    limit: String(Math.min(Math.max(opts.maxResults ?? 50, 1), 100)),
+  });
+
+  const res = await fetch(`https://oauth.reddit.com/search?${params.toString()}`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "User-Agent": opts.userAgent,
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Reddit search failed (${res.status}): ${text.slice(0, 300)}`);
+  }
+
+  const json = (await res.json()) as RedditSearchResponse;
+  const children = json.data?.children ?? [];
+
+  return children
+    .filter((c): c is RedditListingChild & { data: RedditPostData } => c.kind === "t3" && !!c.data?.id)
+    .map((c): RedditMentionResult => {
+      const d = c.data;
+      const text = [d.title, d.selftext].filter(Boolean).join("\n\n");
+      return {
+        id: d.id as string,
+        text,
+        url: d.permalink ? `https://www.reddit.com${d.permalink}` : "",
+        author_name: d.author ?? null,
+        author_handle: d.author ?? null,
+        // Reddit's search endpoint doesn't expose author karma; the
+        // subreddit's subscriber count is the closest available reach proxy.
+        author_reach: num(d.subreddit_subscribers),
+        likes: num(d.ups),
+        comments: num(d.num_comments),
+        published_at:
+          typeof d.created_utc === "number" || typeof d.created_utc === "string"
+            ? new Date(num(d.created_utc) * 1000).toISOString()
+            : null,
+      };
+    });
+}


### PR DESCRIPTION
Fixes #10

## Root cause

Reddit was listed as a supported platform (`MENTION_PLATFORMS` in `src/lib/brand-constants.ts`, `BRAND_SOURCES` in `src/app/settings/page.tsx`, and the platform badge in `src/components/brand/platform-badge.tsx`) but had zero real backend integration — all Reddit demo data came from `scripts/seed.ts` fabrication, and the mention sync route (`src/app/api/brand/[brandId]/mentions/sync/route.ts`) only ever called `searchXMentions` for X.

## Fix

- **`src/lib/reddit-api.ts`** (new): implements Reddit's OAuth2 client-credentials ("script app") grant against `https://www.reddit.com/api/v1/access_token`, with an in-memory token cache keyed on expiry (refetches once expired, refreshes a little early to avoid edge-of-expiry 401s). `searchRedditMentions()` then queries `https://oauth.reddit.com/search` for the brand keyword and maps results into a shape mirroring `XMentionResult` (`id`, `author_name`/`author_handle`, `text`, `url`, `likes`, `comments`, `author_reach`, `published_at`). Every request — including the token request — sends the required descriptive `User-Agent` header, since Reddit throttles/blocks requests that omit one.

  This is the simplest of the missing platform integrations: Reddit's script-app OAuth needs no user-facing consent flow, unlike the Meta/TikTok integrations, which require an OAuth authorization-code dance with a real user.

- **`src/app/api/brand/[brandId]/mentions/sync/route.ts`**: added a Reddit branch guarded by `REDDIT_CLIENT_ID`/`REDDIT_CLIENT_SECRET`/`REDDIT_USER_AGENT`, mirroring the existing X branch and inserting mentions via `insertBrandMention()` with a `reddit_${id}` prefixed id (so ids never collide with X's `x_${id}` ids). Since a second platform now exists, I changed each platform's sync to be independently best-effort (try/catch per platform) rather than the previous X-only hard-412-on-missing-config behavior: the route now sums an `inserted` count across all configured platforms and reports which platforms were `skipped` due to missing config in the response body. The route only 412s if *no* platform is configured at all.

- **`.env.example`**: documented `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USER_AGENT` in the "Social native connectors (optional)" section, following the existing comment style.

`npx tsc --noEmit` passes cleanly with no new errors.

Note: the sync route diff is additive/scoped intentionally — if a sibling PR is touching the same file concurrently, a merge conflict there is expected and should be resolved by a human.