### PR TITLE
feat: add YouTube mention-sync integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,11 @@ GOOGLE_REDIRECT_URI=
 # LINKEDIN_ORGANIZATION_URN=urn:li:organization:123
 # Optional API version header (yyyyMM)
 # LINKEDIN_VERSION=
+# YouTube Data API v3 key, used for brand-keyword mention search (search.list, no OAuth needed)
+# YOUTUBE_API_KEY=
+# OAuth access token + channel id for an owned channel's YouTube Analytics (views/subscribers/watch time)
+# YOUTUBE_CHANNEL_ACCESS_TOKEN=
+# YOUTUBE_CHANNEL_ID=
 
 # Optional 1Password runtime overlay mode for standalone startup:
 # - off: never use 1Password

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  minimatch: ^9.0.7
+
 importers:
 
   .:
@@ -1084,9 +1087,6 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  brace-expansion@1.1.18:
-    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
-
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
@@ -1144,9 +1144,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2031,9 +2028,6 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
-
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
@@ -2933,7 +2927,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.5
+      minimatch: 9.0.9
     transitivePeerDependencies:
       - supports-color
 
@@ -2954,7 +2948,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.5
+      minimatch: 9.0.9
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -3597,11 +3591,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@1.1.18:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -3662,8 +3651,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4005,7 +3992,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.5
+      minimatch: 9.0.9
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -4033,7 +4020,7 @@ snapshots:
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 3.1.5
+      minimatch: 9.0.9
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -4061,7 +4048,7 @@ snapshots:
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.5
+      minimatch: 9.0.9
       object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
@@ -4113,7 +4100,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.5
+      minimatch: 9.0.9
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -4702,10 +4689,6 @@ snapshots:
       picomatch: 2.3.1
 
   mimic-response@3.1.0: {}
-
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,7 @@ allowBuilds:
   esbuild: true
   sharp: true
   unrs-resolver: true
-onlyBuiltDependencies: better-sqlite3,sharp,unrs-resolver
+onlyBuiltDependencies:
+  - better-sqlite3
+  - sharp
+  - unrs-resolver

--- a/src/app/api/brand/[brandId]/mentions/sync/route.ts
+++ b/src/app/api/brand/[brandId]/mentions/sync/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireApiUser } from '@/lib/api-auth';
 import { getBrand, insertBrandMention } from '@/lib/brand-queries';
 import { searchXMentions } from '@/lib/x-api';
+import { searchYouTubeMentions } from '@/lib/youtube-api';
 import { classifyMention } from '@/lib/mention-classify';
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
@@ -21,9 +22,12 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ bra
   if (!brand) return NextResponse.json({ error: 'Brand not found' }, { status: 404 });
   const query = brand.keywords[0] || brand.name;
 
+  let inserted = 0;
+  const skipped: string[] = [];
+  const errors: Record<string, string> = {};
+
   try {
     const results = await searchXMentions({ bearerToken, query, maxResults: 50 });
-    let inserted = 0;
     for (const r of results) {
       const { sentiment, emotion } = classifyMention(r.text);
       insertBrandMention({
@@ -48,8 +52,44 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ bra
       });
       inserted++;
     }
-    return NextResponse.json({ synced: inserted });
   } catch (err) {
     return NextResponse.json({ error: (err as Error).message }, { status: 502 });
   }
+
+  const youtubeApiKey = process.env.YOUTUBE_API_KEY;
+  if (!youtubeApiKey) {
+    skipped.push('youtube');
+  } else {
+    try {
+      const results = await searchYouTubeMentions({ apiKey: youtubeApiKey, query, maxResults: 25 });
+      for (const r of results) {
+        const { sentiment, emotion } = classifyMention(r.text);
+        insertBrandMention({
+          id: `youtube_${r.id}`,
+          brand_id: brandId,
+          source_type: 'social',
+          platform: 'youtube',
+          author_name: r.author_name,
+          author_handle: r.author_handle,
+          author_avatar_url: null,
+          author_reach: r.author_reach,
+          text: r.text,
+          url: r.url || null,
+          likes: r.likes,
+          comments: r.comments,
+          sentiment,
+          emotion,
+          intent: null,
+          is_crisis: false,
+          is_high_impact: r.author_reach > 100_000,
+          published_at: r.published_at,
+        });
+        inserted++;
+      }
+    } catch (err) {
+      errors.youtube = (err as Error).message;
+    }
+  }
+
+  return NextResponse.json({ synced: inserted, skipped, errors });
 }

--- a/src/lib/youtube-api.ts
+++ b/src/lib/youtube-api.ts
@@ -1,0 +1,245 @@
+// NOTE: comment-level mention search (matching the brand keyword inside video *comments*,
+// not just titles/descriptions) is intentionally deferred to a later version -- it needs a
+// commentThreads.list call per video, which is expensive on API quota.
+
+function num(v: unknown): number {
+  const n = typeof v === "number" ? v : typeof v === "string" ? Number(v) : NaN;
+  return Number.isFinite(n) ? n : 0;
+}
+
+async function ytGet<T>(url: string, opts?: { accessToken?: string }): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (opts?.accessToken) headers.Authorization = `Bearer ${opts.accessToken}`;
+
+  const res = await fetch(url, { headers, cache: "no-store" });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`YouTube API failed (${res.status}): ${text.slice(0, 300)}`);
+  }
+  return (await res.json()) as T;
+}
+
+// ─── Mention search (YouTube Data API v3, API-key only) ─────────────────────
+
+export interface YouTubeMentionResult {
+  id: string;
+  text: string;
+  url: string;
+  author_name: string | null;
+  author_handle: string | null;
+  author_reach: number;
+  likes: number;
+  comments: number;
+  published_at: string | null;
+}
+
+interface YouTubeSearchItem {
+  id?: { videoId?: string };
+  snippet?: {
+    title?: string;
+    description?: string;
+    channelTitle?: string;
+    channelId?: string;
+    publishedAt?: string;
+  };
+}
+
+interface YouTubeSearchResponse {
+  items?: YouTubeSearchItem[];
+}
+
+interface YouTubeVideoStatsItem {
+  id?: string;
+  statistics?: {
+    likeCount?: string | number;
+    commentCount?: string | number;
+  };
+}
+
+interface YouTubeVideosResponse {
+  items?: YouTubeVideoStatsItem[];
+}
+
+interface YouTubeChannelStatsItem {
+  id?: string;
+  statistics?: {
+    subscriberCount?: string | number;
+  };
+}
+
+interface YouTubeChannelsResponse {
+  items?: YouTubeChannelStatsItem[];
+}
+
+/**
+ * Searches public videos whose title/description matches `query` (e.g. a brand keyword),
+ * via search.list. Only needs an API key -- no OAuth required for public search.
+ */
+export async function searchYouTubeMentions(opts: {
+  apiKey: string;
+  query: string;
+  maxResults?: number;
+}): Promise<YouTubeMentionResult[]> {
+  const searchParams = new URLSearchParams({
+    part: "snippet",
+    q: opts.query,
+    type: "video",
+    order: "date",
+    maxResults: String(Math.min(Math.max(opts.maxResults ?? 25, 5), 50)),
+    key: opts.apiKey,
+  });
+
+  const search = await ytGet<YouTubeSearchResponse>(
+    `https://www.googleapis.com/youtube/v3/search?${searchParams.toString()}`
+  );
+
+  const items = (search.items ?? []).filter((i) => i.id?.videoId);
+  if (!items.length) return [];
+
+  const videoIds = items.map((i) => i.id!.videoId as string);
+  const channelIds = Array.from(
+    new Set(items.map((i) => i.snippet?.channelId).filter((c): c is string => Boolean(c)))
+  );
+
+  const [videoStats, channelStats] = await Promise.all([
+    ytGet<YouTubeVideosResponse>(
+      `https://www.googleapis.com/youtube/v3/videos?part=statistics&id=${videoIds
+        .map(encodeURIComponent)
+        .join(",")}&key=${opts.apiKey}`
+    ),
+    channelIds.length
+      ? ytGet<YouTubeChannelsResponse>(
+          `https://www.googleapis.com/youtube/v3/channels?part=statistics&id=${channelIds
+            .map(encodeURIComponent)
+            .join(",")}&key=${opts.apiKey}`
+        )
+      : Promise.resolve<YouTubeChannelsResponse>({ items: [] }),
+  ]);
+
+  const statsByVideoId = new Map<string, YouTubeVideoStatsItem>();
+  for (const v of videoStats.items ?? []) {
+    if (v.id) statsByVideoId.set(v.id, v);
+  }
+  const subscribersByChannelId = new Map<string, number>();
+  for (const c of channelStats.items ?? []) {
+    if (c.id) subscribersByChannelId.set(c.id, num(c.statistics?.subscriberCount));
+  }
+
+  return items.map((item): YouTubeMentionResult => {
+    const videoId = item.id!.videoId as string;
+    const snippet = item.snippet;
+    const stats = statsByVideoId.get(videoId);
+    const title = snippet?.title ?? "";
+    const description = snippet?.description ?? "";
+
+    return {
+      id: videoId,
+      text: description ? `${title}\n\n${description}` : title,
+      url: `https://www.youtube.com/watch?v=${videoId}`,
+      author_name: snippet?.channelTitle ?? null,
+      author_handle: snippet?.channelId ?? null,
+      author_reach: snippet?.channelId ? subscribersByChannelId.get(snippet.channelId) ?? 0 : 0,
+      likes: num(stats?.statistics?.likeCount),
+      comments: num(stats?.statistics?.commentCount),
+      published_at: snippet?.publishedAt ?? null,
+    };
+  });
+}
+
+// ─── Owned-channel analytics (YouTube Analytics API, requires OAuth) ────────
+
+export interface YouTubeChannelSummary {
+  channelId: string;
+  subscribers?: number;
+  views: number;
+  estimatedMinutesWatched: number;
+  likes: number;
+  comments: number;
+}
+
+export interface YouTubeChannelSeriesPoint {
+  date: string; // YYYY-MM-DD
+  views: number;
+  estimatedMinutesWatched: number;
+  likes: number;
+  comments: number;
+}
+
+interface YouTubeAnalyticsReportResponse {
+  columnHeaders?: { name?: string }[];
+  rows?: (string | number)[][];
+}
+
+/** Fetches core stats (views/subscribers/watch time) for an owned channel via the YouTube Analytics API. */
+export async function fetchYouTubeChannelAnalytics(opts: {
+  accessToken: string;
+  channelId: string;
+  days: number;
+}): Promise<{ summary: YouTubeChannelSummary; series: YouTubeChannelSeriesPoint[] }> {
+  let subscribers: number | undefined;
+  try {
+    const channelStats = await ytGet<YouTubeChannelsResponse>(
+      `https://www.googleapis.com/youtube/v3/channels?part=statistics&id=${encodeURIComponent(
+        opts.channelId
+      )}`,
+      { accessToken: opts.accessToken }
+    );
+    const parsed = num(channelStats.items?.[0]?.statistics?.subscriberCount);
+    if (parsed > 0) subscribers = parsed;
+  } catch {
+    // ignore -- subscriber count is best-effort
+  }
+
+  const end = new Date();
+  const start = new Date(Date.now() - opts.days * 24 * 60 * 60 * 1000);
+  const isoDay = (d: Date) => d.toISOString().slice(0, 10);
+
+  const reportParams = new URLSearchParams({
+    ids: `channel==${opts.channelId}`,
+    startDate: isoDay(start),
+    endDate: isoDay(end),
+    metrics: "views,estimatedMinutesWatched,likes,comments",
+    dimensions: "day",
+    sort: "day",
+  });
+
+  const report = await ytGet<YouTubeAnalyticsReportResponse>(
+    `https://youtubeanalytics.googleapis.com/v2/reports?${reportParams.toString()}`,
+    { accessToken: opts.accessToken }
+  );
+
+  const headers = (report.columnHeaders ?? []).map((h) => h.name ?? "");
+  const dayIdx = headers.indexOf("day");
+  const viewsIdx = headers.indexOf("views");
+  const minutesIdx = headers.indexOf("estimatedMinutesWatched");
+  const likesIdx = headers.indexOf("likes");
+  const commentsIdx = headers.indexOf("comments");
+
+  const series: YouTubeChannelSeriesPoint[] = (report.rows ?? []).map((row) => ({
+    date: dayIdx >= 0 ? String(row[dayIdx]) : "",
+    views: viewsIdx >= 0 ? num(row[viewsIdx]) : 0,
+    estimatedMinutesWatched: minutesIdx >= 0 ? num(row[minutesIdx]) : 0,
+    likes: likesIdx >= 0 ? num(row[likesIdx]) : 0,
+    comments: commentsIdx >= 0 ? num(row[commentsIdx]) : 0,
+  }));
+
+  const summary = series.reduce(
+    (acc, p) => {
+      acc.views += p.views;
+      acc.estimatedMinutesWatched += p.estimatedMinutesWatched;
+      acc.likes += p.likes;
+      acc.comments += p.comments;
+      return acc;
+    },
+    {
+      channelId: opts.channelId,
+      subscribers,
+      views: 0,
+      estimatedMinutesWatched: 0,
+      likes: 0,
+      comments: 0,
+    } as YouTubeChannelSummary
+  );
+
+  return { summary, series };
+}


### PR DESCRIPTION
Fixes #13

## Root cause
YouTube was listed as a supported platform (`MENTION_PLATFORMS`, `BRAND_SOURCES`, the platform badge) but had zero real backend integration -- all YouTube demo data came from `scripts/seed.ts` fabrication, and the mentions sync route (`src/app/api/brand/[brandId]/mentions/sync/route.ts`) only ever called `searchXMentions`.

## Fix
- Add `src/lib/youtube-api.ts`, mirroring the `x-api.ts` / `linkedin.ts` pattern:
  - `searchYouTubeMentions()` -- YouTube Data API v3 `search.list` (API-key only, no OAuth) to find brand-keyword mentions in video titles/descriptions, enriched with per-video `videos.list` statistics and per-channel `channels.list` subscriber counts for reach.
  - `fetchYouTubeChannelAnalytics()` -- YouTube Analytics API (OAuth) for an owned channel's views/subscribers/watch time, returning a `{ summary, series }` shape mirroring `fetchLinkedInOrgAnalytics`.
  - Per the issue, comment-level mention search (matching the keyword inside video *comments*, not just titles/descriptions) is intentionally deferred to a later version and called out with a one-line code comment -- it would require a `commentThreads.list` call per video, which is expensive on API quota.
- Wire YouTube into the sync route as an additive, independently best-effort branch: it's guarded by `YOUTUBE_API_KEY` like X is guarded by `X_BEARER_TOKEN`, inserts mentions with `youtube_${id}` ids (so they never collide with X's `x_${id}` ids), and is wrapped in its own try/catch so a YouTube failure/missing-config never fails the whole request. The response now reports a summed `inserted` count plus which platforms were `skipped` for missing config and any per-platform `errors`. The existing X-only behavior (its 412 when `X_BEARER_TOKEN` is unset, its insert shape) is unchanged.
- Document the new env vars (`YOUTUBE_API_KEY`, `YOUTUBE_CHANNEL_ACCESS_TOKEN`, `YOUTUBE_CHANNEL_ID`) in `.env.example` under "Social native connectors (optional)", following the file's existing comment style.

## Test plan
- [x] `npx tsc --noEmit` passes cleanly with no new errors
- [ ] Manually verify `POST /api/brand/:brandId/mentions/sync` with `YOUTUBE_API_KEY` set inserts `youtube_*` mentions alongside X's `x_*` mentions
- [ ] Manually verify the route still 412s when `X_BEARER_TOKEN` is unset, and reports `youtube` in `skipped` when `YOUTUBE_API_KEY` is unset