### PR TITLE
feat: add Facebook mention-sync integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,10 @@ GOOGLE_REDIRECT_URI=
 # LINKEDIN_ORGANIZATION_URN=urn:li:organization:123
 # Optional API version header (yyyyMM)
 # LINKEDIN_VERSION=
+# Facebook Page access token (long-lived) for mention/comment sync and Page Insights.
+# Requires Meta App Review for pages_read_engagement / read_insights in production.
+# FACEBOOK_PAGE_ACCESS_TOKEN=
+# FACEBOOK_PAGE_ID=
 
 # Optional 1Password runtime overlay mode for standalone startup:
 # - off: never use 1Password

--- a/src/app/api/brand/[brandId]/mentions/sync/route.ts
+++ b/src/app/api/brand/[brandId]/mentions/sync/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireApiUser } from '@/lib/api-auth';
 import { getBrand, insertBrandMention } from '@/lib/brand-queries';
 import { searchXMentions } from '@/lib/x-api';
+import { searchFacebookPageMentions } from '@/lib/facebook-api';
 import { classifyMention } from '@/lib/mention-classify';
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
@@ -10,9 +11,12 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ bra
   const { brandId } = await params;
 
   const bearerToken = process.env.X_BEARER_TOKEN;
-  if (!bearerToken) {
+  const fbPageAccessToken = process.env.FACEBOOK_PAGE_ACCESS_TOKEN;
+  const fbPageId = process.env.FACEBOOK_PAGE_ID;
+
+  if (!bearerToken && !(fbPageAccessToken && fbPageId)) {
     return NextResponse.json(
-      { error: 'X_BEARER_TOKEN is not configured. Add it to .env.local to enable live X mention syncing.' },
+      { error: 'No platform is configured. Add X_BEARER_TOKEN, or FACEBOOK_PAGE_ACCESS_TOKEN + FACEBOOK_PAGE_ID, to .env.local to enable live mention syncing.' },
       { status: 412 },
     );
   }
@@ -21,35 +25,77 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ bra
   if (!brand) return NextResponse.json({ error: 'Brand not found' }, { status: 404 });
   const query = brand.keywords[0] || brand.name;
 
-  try {
-    const results = await searchXMentions({ bearerToken, query, maxResults: 50 });
-    let inserted = 0;
-    for (const r of results) {
-      const { sentiment, emotion } = classifyMention(r.text);
-      insertBrandMention({
-        id: `x_${r.id}`,
-        brand_id: brandId,
-        source_type: 'social',
-        platform: 'x',
-        author_name: r.author_name,
-        author_handle: r.author_handle,
-        author_avatar_url: null,
-        author_reach: r.author_reach,
-        text: r.text,
-        url: r.url || null,
-        likes: r.likes,
-        comments: r.comments,
-        sentiment,
-        emotion,
-        intent: null,
-        is_crisis: false,
-        is_high_impact: r.author_reach > 100_000,
-        published_at: r.published_at,
-      });
-      inserted++;
+  let inserted = 0;
+  const skipped: string[] = [];
+  const errors: Record<string, string> = {};
+
+  if (bearerToken) {
+    try {
+      const results = await searchXMentions({ bearerToken, query, maxResults: 50 });
+      for (const r of results) {
+        const { sentiment, emotion } = classifyMention(r.text);
+        insertBrandMention({
+          id: `x_${r.id}`,
+          brand_id: brandId,
+          source_type: 'social',
+          platform: 'x',
+          author_name: r.author_name,
+          author_handle: r.author_handle,
+          author_avatar_url: null,
+          author_reach: r.author_reach,
+          text: r.text,
+          url: r.url || null,
+          likes: r.likes,
+          comments: r.comments,
+          sentiment,
+          emotion,
+          intent: null,
+          is_crisis: false,
+          is_high_impact: r.author_reach > 100_000,
+          published_at: r.published_at,
+        });
+        inserted++;
+      }
+    } catch (err) {
+      errors.x = (err as Error).message;
     }
-    return NextResponse.json({ synced: inserted });
-  } catch (err) {
-    return NextResponse.json({ error: (err as Error).message }, { status: 502 });
+  } else {
+    skipped.push('x');
   }
+
+  if (fbPageAccessToken && fbPageId) {
+    try {
+      const results = await searchFacebookPageMentions({ pageAccessToken: fbPageAccessToken, pageId: fbPageId, query, maxResults: 50 });
+      for (const r of results) {
+        const { sentiment, emotion } = classifyMention(r.text);
+        insertBrandMention({
+          id: `facebook_${r.id}`,
+          brand_id: brandId,
+          source_type: 'social',
+          platform: 'facebook',
+          author_name: r.author_name,
+          author_handle: r.author_handle,
+          author_avatar_url: null,
+          author_reach: r.author_reach,
+          text: r.text,
+          url: r.url || null,
+          likes: r.likes,
+          comments: r.comments,
+          sentiment,
+          emotion,
+          intent: null,
+          is_crisis: false,
+          is_high_impact: r.author_reach > 100_000,
+          published_at: r.published_at,
+        });
+        inserted++;
+      }
+    } catch (err) {
+      errors.facebook = (err as Error).message;
+    }
+  } else {
+    skipped.push('facebook');
+  }
+
+  return NextResponse.json({ synced: inserted, skipped, ...(Object.keys(errors).length ? { errors } : {}) });
 }

--- a/src/lib/facebook-api.ts
+++ b/src/lib/facebook-api.ts
@@ -1,0 +1,245 @@
+// Meta Graph API client for a single owned Facebook Page.
+//
+// IMPORTANT SCOPE NOTE: unlike X's `/2/tweets/search/recent`, Meta's Graph API does not
+// offer open keyword search across all of Facebook. A Page access token only grants
+// access to that Page's own posts and the comments on them (plus content the Page has
+// been tagged in, which requires additional review). So "mention discovery" here means:
+// fetch the Page's recent posts, pull the comments on those posts, and keep the ones
+// that mention the brand keyword client-side. That is the honest ceiling of what this
+// API supports without Meta's discretionary, app-reviewed permissions.
+
+const GRAPH_API_VERSION = "v19.0";
+const GRAPH_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
+
+export interface FacebookPageSummary {
+  pageId: string;
+  followers?: number;
+  impressions?: number;
+  reach?: number;
+  engagedUsers?: number;
+  postEngagements?: number;
+  engagementRatePct?: number;
+}
+
+export interface FacebookPageSeriesPoint {
+  date: string; // YYYY-MM-DD
+  impressions: number;
+  reach: number;
+  engagedUsers: number;
+  postEngagements: number;
+}
+
+export interface FacebookMentionResult {
+  id: string;
+  text: string;
+  url: string;
+  author_name: string | null;
+  author_handle: string | null;
+  author_reach: number;
+  likes: number;
+  comments: number;
+  published_at: string | null;
+}
+
+interface FacebookInsightValue {
+  value?: number | string;
+  end_time?: string;
+}
+
+interface FacebookInsightMetric {
+  name?: string;
+  period?: string;
+  values?: FacebookInsightValue[];
+}
+
+interface FacebookInsightsResponse {
+  data?: FacebookInsightMetric[];
+}
+
+interface FacebookCommentFrom {
+  id?: string;
+  name?: string;
+}
+
+interface FacebookComment {
+  id?: string;
+  message?: string;
+  from?: FacebookCommentFrom;
+  created_time?: string;
+  like_count?: number | string;
+  comment_count?: number | string;
+}
+
+interface FacebookCommentsResponse {
+  data?: FacebookComment[];
+  paging?: { next?: string };
+}
+
+interface FacebookPost {
+  id?: string;
+  message?: string;
+  permalink_url?: string;
+  created_time?: string;
+}
+
+interface FacebookPostsResponse {
+  data?: FacebookPost[];
+  paging?: { next?: string };
+}
+
+function num(v: unknown): number {
+  const n = typeof v === "number" ? v : typeof v === "string" ? Number(v) : NaN;
+  return Number.isFinite(n) ? n : 0;
+}
+
+async function fbGet<T>(pageAccessToken: string, path: string, params: Record<string, string> = {}): Promise<T> {
+  const url = new URL(`${GRAPH_BASE}${path}`);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  url.searchParams.set("access_token", pageAccessToken);
+
+  const res = await fetch(url.toString(), { cache: "no-store" });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Facebook Graph API failed (${res.status}): ${text.slice(0, 300)}`);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * Searches comments on the Page's own recent posts for a brand keyword. This is the
+ * closest honest equivalent to X's mention search that the Graph API permits: there is
+ * no cross-Facebook keyword search endpoint, only visibility into your own Page's posts
+ * and their comments. Requires a Page access token with `pages_read_engagement` (and
+ * `pages_show_list`) — most of these permissions require Meta App Review to use in
+ * production.
+ */
+export async function searchFacebookPageMentions(opts: {
+  pageAccessToken: string;
+  pageId: string;
+  query: string;
+  maxResults?: number;
+  maxPosts?: number;
+}): Promise<FacebookMentionResult[]> {
+  const maxResults = Math.min(Math.max(opts.maxResults ?? 50, 1), 200);
+  const maxPosts = Math.min(Math.max(opts.maxPosts ?? 25, 1), 50);
+  const needle = opts.query.trim().toLowerCase();
+
+  const posts = await fbGet<FacebookPostsResponse>(opts.pageAccessToken, `/${encodeURIComponent(opts.pageId)}/posts`, {
+    fields: "id,message,created_time,permalink_url",
+    limit: String(maxPosts),
+  });
+
+  const results: FacebookMentionResult[] = [];
+
+  for (const post of posts.data ?? []) {
+    if (!post.id || results.length >= maxResults) break;
+
+    const comments = await fbGet<FacebookCommentsResponse>(opts.pageAccessToken, `/${encodeURIComponent(post.id)}/comments`, {
+      fields: "id,message,from,created_time,like_count,comment_count",
+      filter: "stream",
+      limit: "100",
+    });
+
+    for (const c of comments.data ?? []) {
+      if (results.length >= maxResults) break;
+      const message = c.message ?? "";
+      if (!needle || !message.toLowerCase().includes(needle)) continue;
+      if (!c.id) continue;
+
+      results.push({
+        id: c.id,
+        text: message,
+        url: post.permalink_url ? `${post.permalink_url}?comment_id=${c.id}` : "",
+        author_name: c.from?.name ?? null,
+        // Graph API does not expose a handle/username-style identifier for commenters.
+        author_handle: null,
+        // Graph API does not expose a commenter's follower count.
+        author_reach: 0,
+        likes: num(c.like_count),
+        comments: num(c.comment_count),
+        published_at: c.created_time ?? null,
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Fetches Page Insights (reach/engagement) for the given day range, mirroring the
+ * shape of fetchLinkedInOrgAnalytics. Requires a Page access token with
+ * `read_insights`. Intended for optional use on /analytics.
+ */
+export async function fetchFacebookPageInsights(opts: {
+  pageAccessToken: string;
+  pageId: string;
+  days: number;
+}): Promise<{ summary: FacebookPageSummary; series: FacebookPageSeriesPoint[] }> {
+  const since = Math.floor((Date.now() - opts.days * 24 * 60 * 60 * 1000) / 1000);
+  const until = Math.floor(Date.now() / 1000);
+
+  const insights = await fbGet<FacebookInsightsResponse>(opts.pageAccessToken, `/${encodeURIComponent(opts.pageId)}/insights`, {
+    metric: "page_impressions,page_impressions_unique,page_engaged_users,page_post_engagements,page_fans",
+    period: "day",
+    since: String(since),
+    until: String(until),
+  });
+
+  const buckets = new Map<string, FacebookPageSeriesPoint>();
+  for (let i = 0; i < opts.days; i++) {
+    const d = new Date(Date.now() - (opts.days - 1 - i) * 24 * 60 * 60 * 1000);
+    const key = d.toISOString().slice(0, 10);
+    buckets.set(key, { date: key, impressions: 0, reach: 0, engagedUsers: 0, postEngagements: 0 });
+  }
+
+  let followers: number | undefined;
+
+  for (const metric of insights.data ?? []) {
+    for (const point of metric.values ?? []) {
+      const day = typeof point.end_time === "string" ? point.end_time.slice(0, 10) : null;
+      const value = num(point.value);
+
+      if (metric.name === "page_fans") {
+        // Lifetime metric — take the latest value as the current follower count.
+        followers = value;
+        continue;
+      }
+
+      if (!day) continue;
+      const bucket = buckets.get(day);
+      if (!bucket) continue;
+
+      if (metric.name === "page_impressions") bucket.impressions = value;
+      else if (metric.name === "page_impressions_unique") bucket.reach = value;
+      else if (metric.name === "page_engaged_users") bucket.engagedUsers = value;
+      else if (metric.name === "page_post_engagements") bucket.postEngagements = value;
+    }
+  }
+
+  const series = Array.from(buckets.values());
+  const totals = series.reduce(
+    (acc, p) => {
+      acc.impressions += p.impressions;
+      acc.reach += p.reach;
+      acc.engagedUsers += p.engagedUsers;
+      acc.postEngagements += p.postEngagements;
+      return acc;
+    },
+    { impressions: 0, reach: 0, engagedUsers: 0, postEngagements: 0 }
+  );
+
+  const engagementRatePct = totals.impressions > 0 ? (totals.postEngagements / totals.impressions) * 100 : 0;
+
+  return {
+    summary: {
+      pageId: opts.pageId,
+      followers,
+      impressions: totals.impressions,
+      reach: totals.reach,
+      engagedUsers: totals.engagedUsers,
+      postEngagements: totals.postEngagements,
+      engagementRatePct,
+    },
+    series,
+  };
+}


### PR DESCRIPTION
Fixes #8

## Root cause
Facebook was listed as a supported platform everywhere in the UI (`MENTION_PLATFORMS` in `src/lib/brand-constants.ts`, `BRAND_SOURCES` in `src/app/settings/page.tsx`, the badge in `src/components/brand/platform-badge.tsx`) but had zero real backend integration — no client, no env var, no live fetch. All Facebook demo data came from the fabricated fixtures in `scripts/seed.ts`.

## Fix
- Added `src/lib/facebook-api.ts`, following the same shape as `src/lib/x-api.ts` / `src/lib/linkedin.ts`:
  - `searchFacebookPageMentions()` — mention/comment discovery scoped honestly to what the Meta Graph API actually allows: fetches the Page's own recent posts and filters their comments for the brand keyword. Meta does **not** offer open keyword search across all of Facebook the way X's `/2/tweets/search/recent` does — a Page access token only grants visibility into that Page's own posts/comments, so this is the honest ceiling of "mention discovery" here.
  - `fetchFacebookPageInsights()` — Page Insights (impressions/reach/engaged users/post engagements/followers), mirroring the summary/series shape of `fetchLinkedInOrgAnalytics`. Not wired into `/analytics` in this PR (kept out of scope per the issue — optional/stretch).
  - New env vars: `FACEBOOK_PAGE_ACCESS_TOKEN`, `FACEBOOK_PAGE_ID`.
- Wired the mention search into `src/app/api/brand/[brandId]/mentions/sync/route.ts`, guarded by those two env vars (mirroring the existing `X_BEARER_TOKEN` guard), inserting via `insertBrandMention()` with platform-prefixed ids (`facebook_${id}`) so they never collide with X's `x_${id}` ids.
- Changed the sync route so each platform is now independently best-effort: previously an unconfigured `X_BEARER_TOKEN` hard-failed the whole request with a 412. Now the route only 412s if *no* platform is configured at all; each configured platform syncs in its own try/catch, `inserted` is summed across all platforms, and the response reports a `skipped` array (platforms missing config) and an `errors` object (platforms that were configured but failed at request time).
- Documented the new env vars in `.env.example` under "Social native connectors (optional)", following the existing comment style.

## Notes for reviewers
- Meta's Graph API requires App Review for most of the mention/comment permissions used here (`pages_read_engagement`, `read_insights`) and authenticates via OAuth-issued access tokens, not a static bearer token like X's. This client assumes a long-lived Page access token has already been provisioned elsewhere — it does not implement the OAuth/token-exchange flow itself.
- The diff to `sync/route.ts` is intentionally kept additive/minimal; if a sibling PR is also touching this file in parallel, a merge conflict there is expected and can be resolved by a human.
- `npx tsc --noEmit` passes with no new errors.