### PR TITLE
feat: implement X posting and fix the post-budget tracking it depends on

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,11 @@ GOOGLE_REDIRECT_URI=
 # Social native connectors (optional)
 # X_BEARER_TOKEN=
 # X_USERNAME=
+# Required to actually publish posts to X (approving a queued X item calls
+# this). This is an OAuth 1.0a user-context token, or an OAuth 2.0
+# user-context access token with the tweet.write scope -- NOT the same
+# credential as the read-only X_BEARER_TOKEN above, which cannot post.
+# X_ACCESS_TOKEN=
 # LINKEDIN_ACCESS_TOKEN=
 # LINKEDIN_ORGANIZATION_URN=urn:li:organization:123
 # Optional API version header (yyyyMM)

--- a/src/app/api/content-item/route.ts
+++ b/src/app/api/content-item/route.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { getDb } from '@/lib/db';
 import { getHermesStateDir } from '@/lib/hermes-state';
 import { requireApiEditor, requireApiUser } from '@/lib/api-auth';
+import { maybePublishToX } from '@/lib/publish-to-x';
 
 export const dynamic = 'force-dynamic';
 
@@ -161,8 +162,25 @@ export async function PATCH(req: NextRequest) {
     const platform = (updated.platform as string | undefined) || 'x';
     const format = (updated.format as string | undefined) || 'short_post';
     const pillar = (updated.pillar as number | null | undefined) ?? null;
-    const status = (updated.status as string | undefined) || 'draft';
+    let status = (updated.status as string | undefined) || 'draft';
     const scheduledFor = (updated.scheduled_for as string | null | undefined) ?? null;
+
+    // Approving/publishing a queued X item is the moment it actually needs
+    // to go out -- wire the real post here rather than just flipping a status flag.
+    const publishResult = await maybePublishToX({
+      platform,
+      previousStatus: (current.status as string | undefined) ?? null,
+      nextStatus: status,
+      text: parsed.full || parsed.preview,
+    });
+    if (publishResult.attempted && !publishResult.ok) {
+      return NextResponse.json({ error: publishResult.error }, { status: publishResult.status });
+    }
+    if (publishResult.attempted && publishResult.ok) {
+      status = 'published';
+      updated.status = status;
+    }
+
     const queueJson = JSON.stringify(updated);
 
     db.transaction(() => {

--- a/src/app/api/content/route.ts
+++ b/src/app/api/content/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getContentPosts, updateContentStatus } from '@/lib/queries';
+import { getContentPostById, getContentPosts, markContentPublished, updateContentStatus } from '@/lib/queries';
 import { writebackContentStatus } from '@/lib/writeback';
 import { requireApiEditor, requireApiUser } from '@/lib/api-auth';
 import { requireUser } from '@/lib/auth';
 import { logAudit } from '@/lib/audit';
+import { maybePublishToX } from '@/lib/publish-to-x';
 
 export async function GET(req: NextRequest) {
   const auth = requireApiUser(req as Request);
@@ -28,13 +29,40 @@ export async function PATCH(req: NextRequest) {
   if (!id || !status) {
     return NextResponse.json({ error: 'id and status required' }, { status: 400 });
   }
-  updateContentStatus(id, status);
-  writebackContentStatus(id, status);
+
+  const current = getContentPostById(id);
+
+  // Approving a queued X post is the moment it actually needs to go out --
+  // wire the real post here rather than just flipping a status flag.
+  const publishResult = await maybePublishToX({
+    platform: current?.platform,
+    previousStatus: current?.status,
+    nextStatus: status,
+    text: current?.full_content || current?.text_preview,
+  });
+  if (publishResult.attempted && !publishResult.ok) {
+    return NextResponse.json({ error: publishResult.error }, { status: publishResult.status });
+  }
+
+  const finalStatus = publishResult.attempted && publishResult.ok ? 'published' : status;
+  if (finalStatus === 'published' && publishResult.attempted) {
+    markContentPublished(id);
+  } else {
+    updateContentStatus(id, finalStatus);
+  }
+  writebackContentStatus(id, finalStatus);
   logAudit({
     actor,
     action: 'content.update_status',
     target: `content:${id}`,
-    detail: { status },
+    detail: {
+      status: finalStatus,
+      ...(publishResult.attempted && publishResult.ok ? { x_post_id: publishResult.tweetId } : {}),
+    },
   });
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({
+    ok: true,
+    status: finalStatus,
+    ...(publishResult.attempted && publishResult.ok ? { x_post_id: publishResult.tweetId } : {}),
+  });
 }

--- a/src/lib/publish-to-x.ts
+++ b/src/lib/publish-to-x.ts
@@ -1,0 +1,75 @@
+import { postXTweet } from '@/lib/x-api';
+import { getXBudget, recordXPost } from '@/lib/x-budget';
+
+export const X_DAILY_POST_LIMIT = 5;
+
+export type PublishToXResult =
+  | { attempted: false }
+  | { attempted: true; ok: true; tweetId: string }
+  | { attempted: true; ok: false; status: number; error: string };
+
+/**
+ * Detects a queued item's approve/publish transition for platform === 'x'
+ * and, if so, actually posts it to X via postXTweet -- this is the step that
+ * used to be entirely missing (the budget widget's "posts" counter stayed at
+ * 0/5 forever because nothing published anything).
+ *
+ * A "transition" is: platform is 'x', the next status is 'ready' or
+ * 'published', and the previous status was neither of those already (so
+ * re-saving an already-approved/published item never reposts it).
+ *
+ * Enforces the daily_post_limit (5) by checking the current budget before
+ * posting, and requires X_ACCESS_TOKEN (an OAuth user-context token with
+ * tweet.write scope -- NOT the read-only X_BEARER_TOKEN) to be configured.
+ *
+ * Returns { attempted: false } when no posting action applies (nothing to
+ * do, caller should proceed with its normal status update).
+ */
+export async function maybePublishToX(opts: {
+  platform: string | null | undefined;
+  previousStatus: string | null | undefined;
+  nextStatus: string | null | undefined;
+  text: string | null | undefined;
+}): Promise<PublishToXResult> {
+  const isFreshXApproval =
+    opts.platform === 'x' &&
+    (opts.nextStatus === 'ready' || opts.nextStatus === 'published') &&
+    opts.previousStatus !== 'ready' &&
+    opts.previousStatus !== 'published';
+
+  if (!isFreshXApproval) return { attempted: false };
+
+  const accessToken = process.env.X_ACCESS_TOKEN;
+  if (!accessToken) {
+    return {
+      attempted: true,
+      ok: false,
+      status: 412,
+      error:
+        'X_ACCESS_TOKEN is not configured. Posting requires an OAuth user-context access token with the tweet.write scope (distinct from the read-only X_BEARER_TOKEN) -- add it to .env.local to enable posting to X.',
+    };
+  }
+
+  const budget = getXBudget();
+  if (budget.posts >= X_DAILY_POST_LIMIT) {
+    return {
+      attempted: true,
+      ok: false,
+      status: 423,
+      error: `Daily X post limit (${X_DAILY_POST_LIMIT}) already reached for today. Try again tomorrow.`,
+    };
+  }
+
+  const text = (opts.text || '').trim();
+  if (!text) {
+    return { attempted: true, ok: false, status: 400, error: 'Post has no content to publish to X.' };
+  }
+
+  try {
+    const posted = await postXTweet({ accessToken, text });
+    recordXPost(posted.id);
+    return { attempted: true, ok: true, tweetId: posted.id };
+  } catch (err) {
+    return { attempted: true, ok: false, status: 502, error: (err as Error).message };
+  }
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -138,6 +138,17 @@ export function updateContentStatus(id: string, status: string): void {
   db.prepare('UPDATE content_posts SET status = ? WHERE id = ?').run(status, id);
 }
 
+export function getContentPostById(id: string): ContentPost | undefined {
+  const db = getDb();
+  return db.prepare('SELECT * FROM content_posts WHERE id = ?').get(id) as ContentPost | undefined;
+}
+
+/** Marks a post published (with published_at) -- used once it has actually gone out (e.g. posted to X). */
+export function markContentPublished(id: string): void {
+  const db = getDb();
+  db.prepare("UPDATE content_posts SET status = 'published', published_at = CURRENT_TIMESTAMP WHERE id = ?").run(id);
+}
+
 // ─── Leads ─────────────────────────────────────────────
 export function getLeads(filters?: {
   status?: string;

--- a/src/lib/x-api.ts
+++ b/src/lib/x-api.ts
@@ -1,3 +1,5 @@
+import { recordXSearchCall } from '@/lib/x-budget';
+
 export interface XSummary {
   username: string;
   followers: number;
@@ -59,6 +61,9 @@ async function xGet<T>(bearerToken: string, url: string): Promise<T> {
     headers: { Authorization: `Bearer ${bearerToken}` },
     cache: "no-store",
   });
+  // Counts against the daily search-call budget regardless of outcome --
+  // the call was made (and consumed rate-limit quota) either way.
+  recordXSearchCall(url);
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(`X API failed (${res.status}): ${text.slice(0, 300)}`);
@@ -229,4 +234,49 @@ export async function searchXMentions(opts: {
       published_at: t.created_at ?? null,
     };
   });
+}
+
+interface XPostTweetResponse {
+  data?: { id?: string; text?: string };
+}
+
+export interface XPostResult {
+  id: string;
+  text: string;
+}
+
+/**
+ * Publishes a tweet via POST https://api.x.com/2/tweets.
+ *
+ * IMPORTANT: unlike xGet's app-only bearer token (X_BEARER_TOKEN, used for
+ * read-only analytics/search above), posting on behalf of an account
+ * requires OAuth 1.0a user context or an OAuth 2.0 user-context access token
+ * with the `tweet.write` scope. A plain app-only bearer token CANNOT post --
+ * it will be rejected by the API. Callers must supply a distinct
+ * user-context credential (e.g. from an `X_ACCESS_TOKEN` env var), never the
+ * app-only `X_BEARER_TOKEN`.
+ */
+export async function postXTweet(opts: {
+  accessToken: string;
+  text: string;
+}): Promise<XPostResult> {
+  const res = await fetch("https://api.x.com/2/tweets", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${opts.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ text: opts.text }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`X post failed (${res.status}): ${text.slice(0, 300)}`);
+  }
+
+  const json = (await res.json()) as XPostTweetResponse;
+  const id = json?.data?.id;
+  if (!id) throw new Error("X post succeeded but response had no tweet id");
+
+  return { id, text: json?.data?.text ?? opts.text };
 }

--- a/src/lib/x-budget.ts
+++ b/src/lib/x-budget.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { getHermesStateDir } from '@/lib/hermes-state';
+
+// Best-effort tracking of daily X API usage against the fixed-tier limits
+// (search calls + posts). Mirrors the JSON shape src/app/api/x-budget/route.ts
+// already expects: { date, calls, posts, queries, posted }.
+//
+// NOTE: this file previously did not exist in the repo even though issue #14
+// ("fix search-call tracking") was closed as completed -- the fix was
+// apparently only ever applied locally and never committed/pushed. This
+// module rebuilds that infrastructure from scratch (see PR for #15).
+
+const STATE_DIR = getHermesStateDir();
+const BUDGET_PATH = path.join(STATE_DIR, 'x-api-budget.json');
+
+export interface XBudget {
+  date: string;
+  calls: number;
+  posts: number;
+  queries: string[];
+  posted: string[];
+}
+
+function today(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+function freshBudget(): XBudget {
+  return { date: today(), calls: 0, posts: 0, queries: [], posted: [] };
+}
+
+function readBudgetFile(): XBudget {
+  try {
+    if (!fs.existsSync(BUDGET_PATH)) return freshBudget();
+    const raw = fs.readFileSync(BUDGET_PATH, 'utf-8').trim();
+    if (!raw) return freshBudget();
+    const parsed = JSON.parse(raw) as Partial<XBudget> | null;
+    if (!parsed || typeof parsed !== 'object') return freshBudget();
+    return {
+      date: typeof parsed.date === 'string' ? parsed.date : today(),
+      calls: typeof parsed.calls === 'number' ? parsed.calls : 0,
+      posts: typeof parsed.posts === 'number' ? parsed.posts : 0,
+      queries: Array.isArray(parsed.queries) ? parsed.queries.filter((q): q is string => typeof q === 'string') : [],
+      posted: Array.isArray(parsed.posted) ? parsed.posted.filter((p): p is string => typeof p === 'string') : [],
+    };
+  } catch {
+    return freshBudget();
+  }
+}
+
+function writeBudgetFile(budget: XBudget): void {
+  try {
+    fs.mkdirSync(path.dirname(BUDGET_PATH), { recursive: true });
+    fs.writeFileSync(BUDGET_PATH, JSON.stringify(budget, null, 2), 'utf-8');
+  } catch {
+    // Best-effort only -- budget tracking must never break the caller.
+  }
+}
+
+/** Resets the in-memory budget to a fresh day if the stored date has rolled over. */
+function withDailyReset(budget: XBudget): XBudget {
+  const t = today();
+  if (budget.date !== t) return freshBudget();
+  return budget;
+}
+
+/** Best-effort read of today's budget (applies the daily reset, but does not persist it). */
+export function getXBudget(): XBudget {
+  return withDailyReset(readBudgetFile());
+}
+
+/**
+ * Records a search API call against today's budget. Increments `calls` and
+ * appends `label` (typically the request URL/query) to `queries`. Resets the
+ * whole budget first if the stored date is not today. Best-effort: never throws.
+ */
+export function recordXSearchCall(label: string): void {
+  try {
+    const budget = withDailyReset(readBudgetFile());
+    budget.calls += 1;
+    budget.queries.push(label);
+    writeBudgetFile(budget);
+  } catch {
+    // Best-effort only.
+  }
+}
+
+/**
+ * Records a successful post against today's budget. Increments `posts` and
+ * appends `label` (typically the resulting tweet id) to `posted`. Resets the
+ * whole budget first if the stored date is not today. Best-effort: never throws.
+ */
+export function recordXPost(label: string): void {
+  try {
+    const budget = withDailyReset(readBudgetFile());
+    budget.posts += 1;
+    budget.posted.push(label);
+    writeBudgetFile(budget);
+  } catch {
+    // Best-effort only.
+  }
+}


### PR DESCRIPTION
Fixes #15

## Root cause

The "X API Budget" widget on Overview (`/`) tracks two counters: search calls and posts. Posts stayed permanently at 0/5 because **nothing in the repo actually published a post to X** — there was no `postXTweet`-equivalent function anywhere, and no code path that called it.

**Important correction / heads-up for reviewers:** issue #14 ("fix search-call tracking") is closed as completed on GitHub, but that fix was never actually committed or pushed to `main` — `src/lib/x-budget.ts` did not exist on `buzzbox/main` as of writing this PR (verified with `git show buzzbox/main:src/lib/x-budget.ts`, which fails). It appears #14 was closed based on a comment claiming the fix was done locally, but the commit never landed. Since the posting feature in #15 depends on that budget-tracking infrastructure, **this PR rebuilds both halves**:

1. The search-call budget tracking that #14 was supposed to deliver.
2. The actual posting feature that #15 asks for.

## What's in this PR

**Part A — search-call budget tracking (rebuilding #14's missing fix)**
- `src/lib/x-budget.ts`: best-effort read/increment/write helper against `<state dir>/x-api-budget.json` (via `getHermesStateDir()`), matching the JSON shape `src/app/api/x-budget/route.ts` already expects (`{date, calls, posts, queries, posted}`), including reset-on-new-day behavior (`budget.date !== today`).
  - `recordXSearchCall(label)` — increments `calls`, appends to `queries`.
  - `recordXPost(label)` — increments `posts`, appends to `posted`.
- Wired `recordXSearchCall()` into `xGet()` in `src/lib/x-api.ts`, the single low-level fetch helper shared by `fetchXAccountAnalytics` and `searchXMentions`, so every real X API search call now counts against the budget.

**Part B — actually posting to X**
- `postXTweet(opts: { accessToken, text })` in `src/lib/x-api.ts`, wrapping `POST https://api.x.com/2/tweets`.
- `src/lib/publish-to-x.ts`: shared helper (`maybePublishToX`) used by both `src/app/api/content/route.ts` and `src/app/api/content-item/route.ts` — detects a queued item's approve/publish transition for `platform === 'x'`, checks the daily post budget (returns a 423 if the limit of 5 is already hit, mirroring the existing 412 pattern used when `X_BEARER_TOKEN` is missing in the mentions/sync route), posts via `postXTweet`, then calls `recordXPost()` on success and marks the post `published`.
- New `getContentPostById` / `markContentPublished` query helpers in `src/lib/queries.ts`.

**⚠️ Deployment prerequisite — read-only vs. posting credentials**

Posting to X requires **OAuth 1.0a user context, or an OAuth 2.0 user-context access token with the `tweet.write` scope**. The existing `X_BEARER_TOKEN` is a plain **app-only** bearer token used today for read-only analytics/search (`fetchXAccountAnalytics`, `searchXMentions`) — it **cannot** post and will be rejected by the API if you try. This PR introduces a distinct env var, `X_ACCESS_TOKEN`, for the posting credential so the two are never confused. Documented in `.env.example` under "Social native connectors (optional)" alongside the existing `X_BEARER_TOKEN` block.

## Testing

- `npx tsc --noEmit` passes cleanly (no new type errors).
- Manually traced both API route transitions (`content/route.ts` PATCH and `content-item/route.ts` PATCH) to confirm the budget check runs before posting, idempotency (no repost on an already-approved/published item), and error responses (412 missing credential, 423 budget exhausted, 502 X API failure).