### PR TITLE
fix: prevent path traversal in cron runs endpoint and require admin capability 

### DIFF
--- a/src/app/api/cron/runs/route.ts
+++ b/src/app/api/cron/runs/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'node:fs';
-import path from 'node:path';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiCapability } from '@/lib/api-auth';
+import { resolveCronRunFilePath } from '@/lib/cron-jobs';
 import { getInstance, resolveOpenClawPaths } from '@/lib/instances';
 
 export const dynamic = 'force-dynamic';
@@ -15,19 +15,21 @@ function getInstanceId(req: NextRequest): string | null {
 }
 
 export async function GET(req: NextRequest) {
-  const auth = requireApiUser(req as unknown as Request);
+  const auth = requireApiCapability(req as unknown as Request, 'manage_system');
   if (auth) return auth;
 
   try {
     const instance = getInstance(getInstanceId(req));
     const { cronDir } = resolveOpenClawPaths(instance);
-    const runsDir = path.join(cronDir, 'runs');
 
     const id = req.nextUrl.searchParams.get('id');
     if (!id) {
       return NextResponse.json({ error: 'Missing id' }, { status: 400 });
     }
-    const file = path.join(runsDir, `${id}.jsonl`);
+    const file = resolveCronRunFilePath(cronDir, id);
+    if (!file) {
+      return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+    }
     if (!fs.existsSync(file)) {
       return NextResponse.json({ runs: [] });
     }

--- a/src/lib/cron-jobs.ts
+++ b/src/lib/cron-jobs.ts
@@ -39,6 +39,26 @@ export function getJobsPath(cronDir: string): string {
   return path.join(cronDir, 'jobs.json');
 }
 
+export function getCronRunsDir(cronDir: string): string {
+  return path.join(path.resolve(cronDir), 'runs');
+}
+
+export function isPathInsideDir(rootDir: string, candidate: string): boolean {
+  const rootResolved = path.resolve(rootDir);
+  const candidateResolved = path.resolve(candidate);
+  if (candidateResolved === rootResolved) return false;
+  return candidateResolved.startsWith(rootResolved + path.sep);
+}
+
+export function resolveCronRunFilePath(cronDir: string, rawId: unknown): string | null {
+  const id = normalizeJobId(rawId);
+  if (!id) return null;
+  const runsDir = getCronRunsDir(cronDir);
+  const file = path.resolve(runsDir, `${id}.jsonl`);
+  if (!isPathInsideDir(runsDir, file)) return null;
+  return file;
+}
+
 function resolveCronJobId(job: CronJobConfig): string | null {
   return normalizeJobId(job.id ?? job.jobId);
 }

--- a/src/lib/cron-runs.test.ts
+++ b/src/lib/cron-runs.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const tempDir = mkdtempSync(path.join(tmpdir(), 'hermes-cron-runs-test-'));
+const dbPath = path.join(tempDir, 'hermes-test.db');
+const openclawHome = path.join(tempDir, 'openclaw-home');
+const runsDir = path.join(openclawHome, 'cron', 'runs');
+
+process.env.HERMES_DB_PATH = dbPath;
+process.env.AUTH_USER = 'admin_test';
+process.env.AUTH_PASS = 'super-secure-pass';
+process.env.API_KEY = 'test-api-key';
+process.env.HERMES_OPENCLAW_HOME = openclawHome;
+
+import { getDb, resetDbForTests } from './db';
+import {
+  createSession,
+  createUser,
+} from './auth';
+import {
+  getCronRunsDir,
+  isPathInsideDir,
+  resolveCronRunFilePath,
+} from './cron-jobs';
+import { GET } from '../app/api/cron/runs/route';
+import { NextRequest } from 'next/server';
+
+before(() => {
+  mkdirSync(runsDir, { recursive: true });
+  writeFileSync(
+    path.join(runsDir, 'testjob.jsonl'),
+    `${JSON.stringify({ run: 1, ok: true })}\n${JSON.stringify({ run: 2, ok: false })}\n`,
+    'utf-8',
+  );
+});
+
+after(() => {
+  resetDbForTests();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function makeRequest(id: string | null, headers: Record<string, string> = {}): NextRequest {
+  const url = new URL('http://localhost/api/cron/runs');
+  if (id !== null) url.searchParams.set('id', id);
+  return new NextRequest(url, { headers });
+}
+
+test('valid job ids resolve to files inside the cron runs dir', () => {
+  for (const id of ['testjob', 'Test-Job_1', 'a', 'job9']) {
+    const resolved = resolveCronRunFilePath(openclawHome, id);
+    assert.ok(resolved, `expected ${id} to resolve`);
+    const expected = path.join(getCronRunsDir(openclawHome), `${id}.jsonl`);
+    assert.equal(path.resolve(resolved), path.resolve(expected));
+    assert.equal(path.basename(resolved), `${id}.jsonl`);
+  }
+});
+
+test('traversal and malformed ids are rejected', () => {
+  const malicious = [
+    '../test',
+    '../../test',
+    '..\\..\\test',
+    '%2e%2e%2ftest',
+    '%2e%2e/',
+    '/etc/passwd',
+    '\\windows\\evil',
+    'C:\\Windows\\evil',
+    'foo/bar',
+    'foo\\bar',
+    '.',
+    '..',
+    'id.jsonl',
+    'has space',
+    `${'a'.repeat(129)}`,
+    '',
+    '   ',
+    '\0evil',
+  ];
+  for (const id of malicious) {
+    assert.equal(resolveCronRunFilePath(openclawHome, id), null, `expected ${JSON.stringify(id)} to be rejected`);
+  }
+  assert.equal(resolveCronRunFilePath(openclawHome, null), null);
+  assert.equal(resolveCronRunFilePath(openclawHome, undefined), null);
+});
+
+test('containment check rejects sibling directories that share a prefix', () => {
+  const root = getCronRunsDir(openclawHome);
+  const sibling = root + '-other';
+  assert.equal(isPathInsideDir(root, path.join(sibling, 'x.jsonl')), false);
+  assert.equal(isPathInsideDir(root, root), false);
+  assert.equal(isPathInsideDir(root, path.join(root, 'x.jsonl')), true);
+  assert.equal(isPathInsideDir(root, path.join(root, 'sub', 'x.jsonl')), true);
+});
+
+test('GET requires authentication', async () => {
+  const res = await GET(makeRequest('testjob'));
+  assert.equal(res.status, 401);
+});
+
+test('GET rejects authenticated viewers (manage_system is admin-only)', async () => {
+  const db = getDb();
+  db.exec("DELETE FROM sessions; DELETE FROM users WHERE username = 'viewer_runs_test';");
+  const viewer = createUser('viewer_runs_test', 'viewer-password-123', 'viewer');
+  const token = createSession(viewer.id);
+
+  const res = await GET(makeRequest('testjob', { cookie: `hermes-session=${token}` }));
+  assert.equal(res.status, 403);
+  const body = await res.json();
+  assert.equal(body.error, 'Access denied');
+});
+
+test('GET returns parsed runs for admin via x-api-key', async () => {
+  const res = await GET(makeRequest('testjob', { 'x-api-key': 'test-api-key' }));
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(body.runs, [{ run: 1, ok: true }, { run: 2, ok: false }]);
+});
+
+test('GET returns empty runs for unknown but valid id', async () => {
+  const res = await GET(makeRequest('nosuchjob', { 'x-api-key': 'test-api-key' }));
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(body.runs, []);
+});
+
+test('GET rejects traversal ids with 400', async () => {
+  for (const id of ['../test', '..\\..\\test', '%2e%2e%2ftest', 'C:\\Windows\\evil', 'foo/bar']) {
+    const res = await GET(makeRequest(id, { 'x-api-key': 'test-api-key' }));
+    assert.equal(res.status, 400, `expected 400 for ${JSON.stringify(id)}`);
+    const body = await res.json();
+    assert.equal(body.error, 'Invalid id');
+  }
+});
+
+test('GET rejects missing id with 400', async () => {
+  const res = await GET(makeRequest(null, { 'x-api-key': 'test-api-key' }));
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error, 'Missing id');
+});


### PR DESCRIPTION
### Summary

`GET /api/cron/runs` accepted an unvalidated `id` query parameter and used it
directly in a filesystem path:

```ts
const file = path.join(runsDir, `${id}.jsonl`);
```

Because `path.join()` normalizes traversal segments (`../`, `..\`,
URL-encoded `%2e%2e%2f`), any authenticated user could escape the intended
`cron/runs` directory. Since `.jsonl` is unconditionally appended, the
concrete primitive was **arbitrary `.jsonl` file read** outside `runsDir`.
The route also used `requireApiUser()`, exposing cron system data to
viewers even though the capability model assigns cron to
`manage_system` (admin-only).

### Changes

| File | Change |
|---|---|
| `src/lib/cron-jobs.ts` | Add `getCronRunsDir()`, `isPathInsideDir()`, `resolveCronRunFilePath()` |
| `src/app/api/cron/runs/route.ts` | Validate id, enforce path containment, elevate authorization |
| `src/lib/cron-runs.test.ts` | New unit tests (validation, containment, traversal, RBAC) |

### Fix details

1. **Input validation** — run ids must pass the existing `normalizeJobId()`
   (`^[a-z0-9][a-z0-9_-]*$`, ≤128 chars). This is the exact format enforced
   on every cron job write path, so all legitimate ids are unaffected.
   Invalid ids return controlled `400 { error: "Invalid id" }`.
2. **Filesystem containment (defense-in-depth)** — the candidate path is
   resolved and must fall strictly inside `runsDir` via a separator-aware
   prefix check (`rootResolved + path.sep`), which also rejects sibling
   directories such as `runsDir-other`. Works on Windows and POSIX.
3. **Authorization** — `requireApiUser` →
   `requireApiCapability(req, 'manage_system')`, per the repository's
   capability model (`src/lib/rbac.ts`: cron belongs to admin-only
   `manage_system`). Uses the existing helper; no new RBAC mechanism.

Behavior preserved: missing id → `400 Missing id`; unknown-but-valid id →
`200 { runs: [] }`.

### Testing

- `pnpm test` — 35 pass / 0 fail (8 new tests covering valid-id resolution;
  18 malformed/traversal inputs incl. encoded, absolute, NUL, over-length;
  sibling-prefix containment; 401 unauthenticated; 403 viewer session;
  200 admin; 400 invalid/missing id)
- `pnpm exec eslint` on changed files — clean
- `git diff --check` — clean

### Notes / follow-ups

- `pnpm run typecheck` currently fails due to a **pre-existing** stale
  `.next/types/validator.ts` entry referencing the removed `/agents` page
  (unrelated to this PR; tracked separately in the audit findings).
- Non-admin users who expand "Runs" on the cron board will now receive 403.
  This is intended per the capability model; a follow-up can hide/disable
  the Runs button for non-admins (`src/components/cron/cron-board.tsx`).