### PR TITLE
Prevent agent workspace sensitive-file direct-read bypass

### DIFF
--- a/src/app/api/agents/workspace/route.ts
+++ b/src/app/api/agents/workspace/route.ts
@@ -8,6 +8,7 @@ import { allowWorkspaceWrite, getInstance, resolveOpenClawPaths } from '@/lib/in
 import {
   getAgentWorkspaceRoot,
   isAllowedWorkspaceWritePath,
+  normalizeWorkspaceRelativePath,
   resolveWorkspacePath,
   WORKSPACE_MAX_FILE_BYTES,
 } from '@/lib/agent-workspace';
@@ -40,17 +41,25 @@ function getInstanceIdFromRequest(req: NextRequest): string | null {
   }
 }
 
+const HIDDEN_DIR_NAMES = new Set([
+  'node_modules',
+  'credentials',
+  'state',
+  'logs',
+  'sessions',
+  'sandboxes',
+  'sandbox',
+]);
+
 function shouldHide(relPosix: string): boolean {
   const segments = relPosix.split('/').filter(Boolean);
-  if (segments.some((s) => s.startsWith('.'))) return true;
-  if (segments.some((s) => s.toLowerCase() === 'node_modules')) return true;
-  if (segments.some((s) => s.toLowerCase() === 'credentials')) return true;
-  if (segments.some((s) => s.toLowerCase() === 'state')) return true;
-  if (segments.some((s) => s.toLowerCase() === 'logs')) return true;
-  if (segments.some((s) => s.toLowerCase() === 'sessions')) return true;
-  if (segments.some((s) => s.toLowerCase() === 'sandboxes')) return true;
-  if (segments.some((s) => s.toLowerCase() === 'sandbox')) return true;
-  return false;
+  return segments.some((s) => {
+    if (s.startsWith('.')) return true;
+    // Windows strips trailing dots/spaces from path segments, so match
+    // sensitive names ignoring them (e.g. "credentials." === "credentials").
+    const name = s.replace(/[. ]+$/, '').toLowerCase();
+    return HIDDEN_DIR_NAMES.has(name);
+  });
 }
 
 async function listDir(root: string, relDir: string, depth: number, maxEntries: number): Promise<Entry[]> {
@@ -195,6 +204,12 @@ export async function GET(req: NextRequest) {
 
     const abs = resolveWorkspacePath(root.abs, rel);
     if (!abs) return NextResponse.json({ error: 'Invalid path' }, { status: 400 });
+
+    // Direct reads must obey the same sensitive-path policy as listings.
+    const relNormalized = normalizeWorkspaceRelativePath(rel);
+    if (relNormalized && shouldHide(relNormalized)) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
 
     const st = await fs.stat(abs).catch(() => null);
     if (!st) return NextResponse.json({ error: 'Not found' }, { status: 404 });

--- a/src/lib/agent-workspace.test.ts
+++ b/src/lib/agent-workspace.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import path from 'node:path';
 
-import { isAllowedWorkspaceWritePath, resolveWorkspacePath } from './agent-workspace';
+import { isAllowedWorkspaceWritePath, normalizeWorkspaceRelativePath, resolveWorkspacePath } from './agent-workspace';
 
 test('resolveWorkspacePath blocks absolute and traversal paths', () => {
   const root = path.resolve('/tmp/workspace-root');
@@ -11,6 +11,22 @@ test('resolveWorkspacePath blocks absolute and traversal paths', () => {
   assert.equal(resolveWorkspacePath(root, '/etc/passwd'), null);
   assert.equal(resolveWorkspacePath(root, 'a/../../b'), null);
   assert.ok(resolveWorkspacePath(root, 'notes.md')?.startsWith(root + path.sep));
+});
+
+test('normalizeWorkspaceRelativePath normalizes separators and collapses dot segments', () => {
+  assert.equal(normalizeWorkspaceRelativePath('a/b/c.md'), 'a/b/c.md');
+  assert.equal(normalizeWorkspaceRelativePath('a\\b\\c.md'), 'a/b/c.md');
+  assert.equal(normalizeWorkspaceRelativePath('a/./b/../c.txt'), 'a/c.txt');
+  assert.equal(normalizeWorkspaceRelativePath('  notes.md  '), 'notes.md');
+});
+
+test('normalizeWorkspaceRelativePath rejects traversal, absolute paths, and NUL bytes', () => {
+  assert.equal(normalizeWorkspaceRelativePath('../x'), null);
+  assert.equal(normalizeWorkspaceRelativePath('..'), null);
+  assert.equal(normalizeWorkspaceRelativePath('a/../../b'), null);
+  assert.equal(normalizeWorkspaceRelativePath('/etc/passwd'), null);
+  assert.equal(normalizeWorkspaceRelativePath('a\0b'), null);
+  assert.equal(normalizeWorkspaceRelativePath(''), null);
 });
 
 test('isAllowedWorkspaceWritePath allows safe text files and blocks sensitive paths', () => {

--- a/src/lib/agent-workspace.ts
+++ b/src/lib/agent-workspace.ts
@@ -42,7 +42,7 @@ export function isAllowedWorkspaceWritePath(relPath: string): boolean {
   return ALLOWED_EXTS.has(ext);
 }
 
-export function resolveWorkspacePath(root: string, relPath: string): string | null {
+export function normalizeWorkspaceRelativePath(relPath: string): string | null {
   const p = String(relPath || '').trim();
   if (!p) return null;
   if (p.includes('\0')) return null;
@@ -50,6 +50,12 @@ export function resolveWorkspacePath(root: string, relPath: string): string | nu
 
   const normalized = path.posix.normalize(p.replaceAll('\\', '/'));
   if (normalized.startsWith('../') || normalized === '..') return null;
+  return normalized;
+}
+
+export function resolveWorkspacePath(root: string, relPath: string): string | null {
+  const normalized = normalizeWorkspaceRelativePath(relPath);
+  if (!normalized) return null;
 
   // Use platform path.resolve and then enforce root prefix.
   const resolved = path.resolve(root, normalized);

--- a/src/lib/agents-workspace-route.test.ts
+++ b/src/lib/agents-workspace-route.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const tempDir = mkdtempSync(path.join(tmpdir(), 'hermes-ws-route-test-'));
+const dbPath = path.join(tempDir, 'hermes-test.db');
+const wsRoot = path.join(tempDir, 'workspace');
+
+process.env.HERMES_DB_PATH = dbPath;
+process.env.AUTH_USER = 'admin_test';
+process.env.AUTH_PASS = 'super-secure-pass';
+process.env.API_KEY = 'test-api-key';
+process.env.HERMES_AGENT_WORKSPACE_DIR = wsRoot;
+
+import { getDb, resetDbForTests } from './db';
+import { createSession, createUser } from './auth';
+import { GET } from '../app/api/agents/workspace/route';
+import { NextRequest } from 'next/server';
+
+before(() => {
+  const files: Array<[string, string]> = [
+    ['readme.md', '# hello'],
+    ['notes/sub/page.md', 'page'],
+    ['credentials/tokens.json', '{"token":"TEST-PLACEHOLDER"}'],
+    ['.env', 'PLACEHOLDER=1'],
+    ['state/agent-state.json', '{}'],
+    ['logs/run.log', 'log'],
+    ['sessions/s1.jsonl', '{}'],
+    ['sandboxes/sb/x.txt', 'x'],
+    ['sandbox/y.txt', 'y'],
+    ['node_modules/pkg/index.js', 'm'],
+    ['.hidden/nested.txt', 'h'],
+    ['subdir/.dot/file.txt', 'd'],
+    ['STATE/lower-case-check.json', '{}'],
+  ];
+  for (const [rel, content] of files) {
+    const abs = path.join(wsRoot, rel);
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, content, 'utf-8');
+  }
+});
+
+after(() => {
+  resetDbForTests();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function makeRequest(pathValue: string | null, headers: Record<string, string> = {}): NextRequest {
+  const url = new URL('http://localhost/api/agents/workspace');
+  if (pathValue !== null) url.searchParams.set('path', pathValue);
+  return new NextRequest(url, { headers });
+}
+
+const ADMIN = { 'x-api-key': 'test-api-key' };
+
+test('GET requires authentication', async () => {
+  const res = await GET(makeRequest('readme.md'));
+  assert.equal(res.status, 401);
+});
+
+test('legitimate workspace files remain readable', async () => {
+  const res = await GET(makeRequest('readme.md', ADMIN));
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.content, '# hello');
+
+  const nested = await GET(makeRequest('notes/sub/page.md', ADMIN));
+  assert.equal(nested.status, 200);
+  const nestedBody = await nested.json();
+  assert.equal(nestedBody.content, 'page');
+});
+
+test('authenticated viewer can still read legitimate files (auth unchanged)', async () => {
+  const db = getDb();
+  db.exec("DELETE FROM sessions; DELETE FROM users WHERE username = 'viewer_ws_test';");
+  const viewer = createUser('viewer_ws_test', 'viewer-password-123', 'viewer');
+  const token = createSession(viewer.id);
+
+  const res = await GET(makeRequest('readme.md', { cookie: `hermes-session=${token}` }));
+  assert.equal(res.status, 200);
+});
+
+test('direct reads of hidden sensitive paths are rejected with 404', async () => {
+  const hidden = [
+    'credentials/tokens.json',
+    '.env',
+    'state/agent-state.json',
+    'logs/run.log',
+    'sessions/s1.jsonl',
+    'sandboxes/sb/x.txt',
+    'sandbox/y.txt',
+    'node_modules/pkg/index.js',
+    '.hidden/nested.txt',
+    'subdir/.dot/file.txt',
+    'STATE/lower-case-check.json',
+    'credentials\\tokens.json',
+    './credentials/tokens.json',
+    'credentials./tokens.json',
+    'state /agent-state.json',
+  ];
+  for (const p of hidden) {
+    const res = await GET(makeRequest(p, ADMIN));
+    assert.equal(res.status, 404, `expected 404 for ${JSON.stringify(p)}`);
+    const body = await res.json();
+    assert.equal(body.error, 'Not found');
+  }
+});
+
+test('direct requests for hidden directories are rejected with 404', async () => {
+  for (const p of ['credentials', 'state', 'logs', '.hidden']) {
+    const res = await GET(makeRequest(p, ADMIN));
+    assert.equal(res.status, 404, `expected 404 for directory ${JSON.stringify(p)}`);
+  }
+});
+
+test('traversal attempts remain rejected with 400', async () => {
+  for (const p of ['../outside.txt', 'a/../../b', '/etc/passwd']) {
+    const res = await GET(makeRequest(p, ADMIN));
+    assert.equal(res.status, 400, `expected 400 for ${JSON.stringify(p)}`);
+    const body = await res.json();
+    assert.equal(body.error, 'Invalid path');
+  }
+});
+
+test('unknown but legitimate paths still return the existing 404 response', async () => {
+  const res = await GET(makeRequest('does-not-exist.md', ADMIN));
+  assert.equal(res.status, 404);
+  const body = await res.json();
+  assert.equal(body.error, 'Not found');
+});
+
+test('directory listing still hides sensitive entries', async () => {
+  const res = await GET(makeRequest(null, ADMIN));
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  const paths = (body.entries || []).map((e: { path: string }) => e.path);
+  assert.ok(paths.includes('readme.md'), 'expected legit entry in listing');
+  assert.ok(!paths.some((p: string) => p.split('/')[0].toLowerCase() === 'credentials'));
+  assert.ok(!paths.some((p: string) => p.startsWith('.')));
+});


### PR DESCRIPTION
### Summary

The agent workspace API hid sensitive paths (`credentials/`, `state/`,
`logs/`, `sessions/`, `sandboxes/`, `sandbox/`, `node_modules`, dotfiles)
from directory listings via `shouldHide()`, but the direct GET file-read
path only applied `resolveWorkspacePath()` (traversal guard) and never
checked the hide policy. Any authenticated user could therefore read a
hidden file by requesting its path directly:

    GET /api/agents/workspace?path=credentials/tokens.json   # 200, file content
    GET /api/agents/workspace?path=.env                      # 200, file content

### Changes

| File | Change |
|---|---|
| `src/lib/agent-workspace.ts` | Extract path normalization into exported `normalizeWorkspaceRelativePath()`; `resolveWorkspacePath()` now delegates to it |
| `src/app/api/agents/workspace/route.ts` | Direct GET reads now apply the same `shouldHide()` policy as listings; hidden paths return 404. Segment matching hardened against Windows trailing-dot/space stripping |
| `src/lib/agent-workspace.test.ts` | Unit tests for the new normalizer |
| `src/lib/agents-workspace-route.test.ts` | New route-level handler tests |

### Fix details

1. **Policy reuse** — after path validation and before `fs.stat`, the GET
   handler normalizes the requested relative path with the *same*
   normalizer used for all read/write resolution, then applies the
   existing `shouldHide()`. Hidden files **and** directories return
   `404 { error: "Not found" }` — indistinguishable from a missing file,
   so hidden paths are not confirmed to exist.
2. **Single source of truth** — `normalizeWorkspaceRelativePath()` is the
   exact normalization previously inlined in `resolveWorkspacePath()`
   (trim, NUL rejection, absolute rejection, `\` → `/`, POSIX normalize,
   traversal rejection). This matters because raw input containing
   backslashes would otherwise defeat `/`-segment matching.
3. **Windows hardening** — Win32 strips trailing dots/spaces from path
   segments, so `credentials./x` resolves to the real `credentials`
   directory while failing an exact string compare. Sensitive names are
   now matched ignoring trailing dots/spaces.
4. **Behavior preserved** — legitimate files remain readable; traversal
   attempts still return `400 Invalid path`; unknown-but-valid paths keep
   the existing 404; authorization unchanged (`requireApiUser` on reads,
   editor-gated writes).

### Testing

- `pnpm test` — 36 pass / 0 fail:
  - positive: legit/nested file reads (admin + viewer session), listing intact
  - negative: all hidden categories incl. descendants, nested dotfiles,
    case variants, backslash form, `./`-prefixed, trailing-dot/space forms,
    direct hidden-directory requests → 404
  - traversal: `../`, `a/../../b`, absolute → 400
- `pnpm exec eslint` on changed files — clean
- `git diff --check` — clean

### Notes / follow-ups

- `pnpm run typecheck` fails due to the known pre-existing stale
  `.next/types/validator.ts` entry (removed `/agents` page) — unrelated
  to this PR, tracked separately in the audit findings.
- Symlink escape remains out of scope (lexical resolution only); candidate
  follow-up: `fs.realpath` containment check.
- `isAllowedWorkspaceWritePath()` omits `sessions`/`sandboxes`/`sandbox`
  from its sensitive list vs `shouldHide()` — harmless today (extension
  allowlist also blocks), worth unifying later.