### PR TITLE
fix: enforce RBAC capabilities on mutation endpoints

### DIFF
--- a/src/app/api/brand/[brandId]/alerts/[alertId]/check/route.ts
+++ b/src/app/api/brand/[brandId]/alerts/[alertId]/check/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiEditor } from '@/lib/api-auth';
 import { checkBrandAlert } from '@/lib/brand-queries';
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ alertId: string }> }) {
-  const auth = requireApiUser(req as Request);
+  const auth = requireApiEditor(req as Request);
   if (auth) return auth;
   const { alertId } = await params;
   return NextResponse.json(checkBrandAlert(alertId));

--- a/src/app/api/brand/[brandId]/alerts/[alertId]/route.ts
+++ b/src/app/api/brand/[brandId]/alerts/[alertId]/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiEditor } from '@/lib/api-auth';
 import { deleteBrandAlert } from '@/lib/brand-queries';
 
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ alertId: string }> }) {
-  const auth = requireApiUser(req as Request);
+  const auth = requireApiEditor(req as Request);
   if (auth) return auth;
   const { alertId } = await params;
   deleteBrandAlert(alertId);

--- a/src/app/api/brand/[brandId]/alerts/route.ts
+++ b/src/app/api/brand/[brandId]/alerts/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiEditor, requireApiUser } from '@/lib/api-auth';
 import { getBrandAlerts, createBrandAlert } from '@/lib/brand-queries';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ bran
 }
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
-  const auth = requireApiUser(req as Request);
+  const auth = requireApiEditor(req as Request);
   if (auth) return auth;
   const { brandId } = await params;
   const body = await req.json();

--- a/src/app/api/brand/[brandId]/campaigns/[campaignId]/route.ts
+++ b/src/app/api/brand/[brandId]/campaigns/[campaignId]/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiEditor } from '@/lib/api-auth';
 import { deleteBrandCampaign } from '@/lib/brand-queries';
 
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ campaignId: string }> }) {
-  const auth = requireApiUser(req as Request);
+  const auth = requireApiEditor(req as Request);
   if (auth) return auth;
   const { campaignId } = await params;
   deleteBrandCampaign(campaignId);

--- a/src/app/api/brand/[brandId]/campaigns/route.ts
+++ b/src/app/api/brand/[brandId]/campaigns/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiEditor, requireApiUser } from '@/lib/api-auth';
 import { getBrandCampaigns, createBrandCampaign } from '@/lib/brand-queries';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ bran
 }
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
-  const auth = requireApiUser(req as Request);
+  const auth = requireApiEditor(req as Request);
   if (auth) return auth;
   const { brandId } = await params;
   const body = await req.json();

--- a/src/app/api/brand/[brandId]/competitors/[competitorId]/route.ts
+++ b/src/app/api/brand/[brandId]/competitors/[competitorId]/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiEditor } from '@/lib/api-auth';
 import { deleteBrandCompetitor } from '@/lib/brand-queries';
 
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ competitorId: string }> }) {
-  const auth = requireApiUser(req as Request);
+  const auth = requireApiEditor(req as Request);
   if (auth) return auth;
   const { competitorId } = await params;
   deleteBrandCompetitor(competitorId);

--- a/src/app/api/brand/[brandId]/competitors/route.ts
+++ b/src/app/api/brand/[brandId]/competitors/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiEditor, requireApiUser } from '@/lib/api-auth';
 import { getBrandCompetitors, createBrandCompetitor } from '@/lib/brand-queries';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ bran
 }
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
-  const auth = requireApiUser(req as Request);
+  const auth = requireApiEditor(req as Request);
   if (auth) return auth;
   const { brandId } = await params;
   const body = await req.json();

--- a/src/app/api/brand/[brandId]/digests/route.ts
+++ b/src/app/api/brand/[brandId]/digests/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiEditor, requireApiUser } from '@/lib/api-auth';
 import { getBrandDigests, createBrandDigest } from '@/lib/brand-queries';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ bran
 }
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
-  const auth = requireApiUser(req as Request);
+  const auth = requireApiEditor(req as Request);
   if (auth) return auth;
   const { brandId } = await params;
   const real = req.nextUrl.searchParams.get('real') === 'true';

--- a/src/app/api/brand/[brandId]/mentions/[mentionId]/route.ts
+++ b/src/app/api/brand/[brandId]/mentions/[mentionId]/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiEditor } from '@/lib/api-auth';
 import { getBrandMention, patchMention } from '@/lib/brand-queries';
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ mentionId: string }> }) {
-  const auth = requireApiUser(req as Request);
+  const auth = requireApiEditor(req as Request);
   if (auth) return auth;
   const { mentionId } = await params;
   const body = await req.json();

--- a/src/app/api/brand/[brandId]/mentions/sync/route.ts
+++ b/src/app/api/brand/[brandId]/mentions/sync/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiEditor } from '@/lib/api-auth';
 import { getBrand, insertBrandMention } from '@/lib/brand-queries';
 import { searchXMentions } from '@/lib/x-api';
 import { searchInstagramMentions } from '@/lib/instagram-api';
@@ -8,7 +8,7 @@ import { searchRedditMentions } from '@/lib/reddit-api';
 import { classifyMention } from '@/lib/mention-classify';
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
-  const auth = requireApiUser(req as Request);
+  const auth = requireApiEditor(req as Request);
   if (auth) return auth;
   const { brandId } = await params;
 

--- a/src/app/api/brand/[brandId]/route.ts
+++ b/src/app/api/brand/[brandId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiEditor, requireApiUser } from '@/lib/api-auth';
 import { getBrand, updateBrand } from '@/lib/brand-queries';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
@@ -12,7 +12,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ bran
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ brandId: string }> }) {
-  const auth = requireApiUser(req as Request);
+  const auth = requireApiEditor(req as Request);
   if (auth) return auth;
   const { brandId } = await params;
   const existing = getBrand(brandId);

--- a/src/app/api/chat/sync-sessions/route.ts
+++ b/src/app/api/chat/sync-sessions/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
 import fs from 'fs';
 import path from 'path';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiCapability, requireApiUser } from '@/lib/api-auth';
 import { getAgentIds } from '@/lib/agent-config';
 import { getInstance, resolveOpenClawPaths } from '@/lib/instances';
 
@@ -33,7 +33,7 @@ interface SessionEntry {
  * into the messages table. Tracks progress via session_sync table.
  */
 export async function POST(request: Request) {
-  const auth = requireApiUser(request as Request);
+  const auth = requireApiCapability(request as Request, 'manage_system');
   if (auth) return auth;
 
   const instance = getInstance(getInstanceId(request));

--- a/src/app/api/memory-alert-policy/route.ts
+++ b/src/app/api/memory-alert-policy/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiCapability, requireApiUser } from '@/lib/api-auth';
 import { requireUser } from '@/lib/auth';
 import { allowPolicyWrite, getInstance, resolveOpenClawPaths } from '@/lib/instances';
 
@@ -106,7 +106,7 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
-  const auth = requireApiUser(request);
+  const auth = requireApiCapability(request, 'manage_system');
   if (auth) return auth;
   if (!allowPolicyWrite()) {
     return NextResponse.json(

--- a/src/app/api/memory-policy/route.ts
+++ b/src/app/api/memory-policy/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiCapability, requireApiUser } from '@/lib/api-auth';
 import { requireUser } from '@/lib/auth';
 import { allowPolicyWrite, getInstance, resolveOpenClawPaths } from '@/lib/instances';
 
@@ -111,7 +111,7 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
-  const auth = requireApiUser(request);
+  const auth = requireApiCapability(request, 'manage_system');
   if (auth) return auth;
   if (!allowPolicyWrite()) {
     return NextResponse.json(

--- a/src/app/api/outreach/pause/route.ts
+++ b/src/app/api/outreach/pause/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'node:fs';
 import path from 'node:path';
 import { getUserFromRequest } from '@/lib/auth';
+import { requireApiCapability } from '@/lib/api-auth';
 import { getDb } from '@/lib/db';
 import { getHermesStateDir } from '@/lib/hermes-state';
 
@@ -9,6 +10,9 @@ const STATE_DIR = getHermesStateDir();
 const FLAG_PATH = path.join(STATE_DIR, 'sending-paused.flag');
 
 export async function POST(req: NextRequest) {
+  const auth = requireApiCapability(req as unknown as Request, 'manage_system');
+  if (auth) return auth;
+
   try {
     const user = getUserFromRequest(req);
     if (!user) {

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server';
 import { startSync, syncAll } from '@/lib/sync';
-import { requireApiUser } from '@/lib/api-auth';
+import { requireApiCapability, requireApiUser } from '@/lib/api-auth';
 
 // Start background sync on first import
 let started = false;
 
 export async function POST(request: Request) {
-  const auth = requireApiUser(request as Request);
+  const auth = requireApiCapability(request as Request, 'manage_system');
   if (auth) return auth;
   if (!started) {
     startSync();

--- a/src/lib/rbac-brand-mutations.test.ts
+++ b/src/lib/rbac-brand-mutations.test.ts
@@ -1,0 +1,243 @@
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { NextRequest } from 'next/server';
+
+const tempDir = mkdtempSync(path.join(tmpdir(), 'hermes-rbac-brand-test-'));
+const dbPath = path.join(tempDir, 'hermes-test.db');
+console.log('[rbac-brand] module eval, dbPath:', dbPath);
+
+process.env.HERMES_DB_PATH = dbPath;
+process.env.AUTH_USER = 'admin_test';
+process.env.AUTH_PASS = 'super-secure-pass';
+process.env.API_KEY = 'test-api-key';
+// Ensure no social connectors are configured so mentions/sync stops at its
+// 412 precondition instead of calling external services.
+delete process.env.X_BEARER_TOKEN;
+delete process.env.TIKTOK_ACCESS_TOKEN;
+delete process.env.INSTAGRAM_ACCESS_TOKEN;
+delete process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID;
+delete process.env.REDDIT_CLIENT_ID;
+delete process.env.REDDIT_CLIENT_SECRET;
+delete process.env.REDDIT_USER_AGENT;
+
+// NOTE: src/lib/db.ts captures its database path at module load, so db/auth
+// and every route module must be dynamically imported inside before() AFTER
+// the env vars above are configured.
+type DbModule = typeof import('./db');
+type AuthModule = typeof import('./auth');
+let dbm: DbModule;
+let authm: AuthModule;
+let brandPatch: typeof import('../app/api/brand/[brandId]/route')['PATCH'];
+let alertsPost: typeof import('../app/api/brand/[brandId]/alerts/route')['POST'];
+let alertDelete: typeof import('../app/api/brand/[brandId]/alerts/[alertId]/route')['DELETE'];
+let alertCheckPost: typeof import('../app/api/brand/[brandId]/alerts/[alertId]/check/route')['POST'];
+let campaignsPost: typeof import('../app/api/brand/[brandId]/campaigns/route')['POST'];
+let campaignDelete: typeof import('../app/api/brand/[brandId]/campaigns/[campaignId]/route')['DELETE'];
+let competitorsPost: typeof import('../app/api/brand/[brandId]/competitors/route')['POST'];
+let competitorDelete: typeof import('../app/api/brand/[brandId]/competitors/[competitorId]/route')['DELETE'];
+let digestsPost: typeof import('../app/api/brand/[brandId]/digests/route')['POST'];
+let mentionPatch: typeof import('../app/api/brand/[brandId]/mentions/[mentionId]/route')['PATCH'];
+let mentionsSyncPost: typeof import('../app/api/brand/[brandId]/mentions/sync/route')['POST'];
+
+const BRAND_ID = 'brand_rbac_test';
+let viewerCookie: string;
+let editorCookie: string;
+let adminCookie: string;
+
+type Ctx<T extends Record<string, string>> = { params: Promise<T> };
+function ctx<T extends Record<string, string>>(params: T): Ctx<T> {
+  return { params: Promise.resolve(params) };
+}
+function req(url: string, init: RequestInit = {}): NextRequest {
+  return new NextRequest(new URL(url), init as never);
+}
+
+function count(table: string): number {
+  return (dbm.getDb().prepare(`SELECT COUNT(*) as c FROM ${table}`).get() as { c: number }).c;
+}
+
+// tsx emits CJS here, so dynamic imports wrap exports under `.default`.
+async function imp<T>(specifier: string): Promise<T> {
+  const m = (await import(specifier)) as { default?: T };
+  return (m.default ?? (m as unknown as T)) as T;
+}
+
+before(async () => {
+  dbm = await imp<typeof import('./db')>('./db');
+  authm = await imp<typeof import('./auth')>('./auth');
+  brandPatch = (await imp<typeof import('../app/api/brand/[brandId]/route')>('../app/api/brand/[brandId]/route')).PATCH;
+  alertsPost = (await imp<typeof import('../app/api/brand/[brandId]/alerts/route')>('../app/api/brand/[brandId]/alerts/route')).POST;
+  alertDelete = (await imp<typeof import('../app/api/brand/[brandId]/alerts/[alertId]/route')>('../app/api/brand/[brandId]/alerts/[alertId]/route')).DELETE;
+  alertCheckPost = (await imp<typeof import('../app/api/brand/[brandId]/alerts/[alertId]/check/route')>('../app/api/brand/[brandId]/alerts/[alertId]/check/route')).POST;
+  campaignsPost = (await imp<typeof import('../app/api/brand/[brandId]/campaigns/route')>('../app/api/brand/[brandId]/campaigns/route')).POST;
+  campaignDelete = (await imp<typeof import('../app/api/brand/[brandId]/campaigns/[campaignId]/route')>('../app/api/brand/[brandId]/campaigns/[campaignId]/route')).DELETE;
+  competitorsPost = (await imp<typeof import('../app/api/brand/[brandId]/competitors/route')>('../app/api/brand/[brandId]/competitors/route')).POST;
+  competitorDelete = (await imp<typeof import('../app/api/brand/[brandId]/competitors/[competitorId]/route')>('../app/api/brand/[brandId]/competitors/[competitorId]/route')).DELETE;
+  digestsPost = (await imp<typeof import('../app/api/brand/[brandId]/digests/route')>('../app/api/brand/[brandId]/digests/route')).POST;
+  mentionPatch = (await imp<typeof import('../app/api/brand/[brandId]/mentions/[mentionId]/route')>('../app/api/brand/[brandId]/mentions/[mentionId]/route')).PATCH;
+  mentionsSyncPost = (await imp<typeof import('../app/api/brand/[brandId]/mentions/sync/route')>('../app/api/brand/[brandId]/mentions/sync/route')).POST;
+
+  authm.ensureAuthTables();
+  const db = dbm.getDb();
+  db.exec("DELETE FROM sessions; DELETE FROM users WHERE username LIKE 'rbac_%';");
+  const viewer = authm.createUser('rbac_brand_viewer', 'viewer-password-123', 'viewer');
+  viewerCookie = `hermes-session=${authm.createSession(viewer.id)}`;
+  const editor = authm.createUser('rbac_brand_editor', 'editor-password-123', 'editor');
+  editorCookie = `hermes-session=${authm.createSession(editor.id)}`;
+  const admin = authm.createUser('rbac_brand_admin', 'admin-password-123', 'admin');
+  adminCookie = `hermes-session=${authm.createSession(admin.id)}`;
+
+  db.prepare('INSERT INTO brands (id, name, keywords, sources) VALUES (?, ?, ?, ?)').run(
+    BRAND_ID,
+    'TestBrand',
+    '[]',
+    '[]',
+  );
+  db.prepare(
+    `INSERT INTO brand_mentions (id, brand_id, source_type, platform, text) VALUES (?, ?, 'social', 'x', 'mention text')`,
+  ).run('mention_rbac_test', BRAND_ID);
+});
+
+after(() => {
+  dbm.resetDbForTests();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('brand PATCH: unauthenticated 401, viewer 403 without DB change, editor/admin allowed', async () => {
+  const call = (headers: Record<string, string>) =>
+    brandPatch(req('http://localhost/x', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify({ name: 'RenamedBrand' }),
+    }), ctx({ brandId: BRAND_ID }));
+
+  assert.equal((await call({})).status, 401);
+
+  assert.equal((await call({ cookie: viewerCookie })).status, 403);
+  let name = (dbm.getDb().prepare('SELECT name FROM brands WHERE id = ?').get(BRAND_ID) as { name: string }).name;
+  assert.equal(name, 'TestBrand', 'viewer must not be able to rename the brand');
+
+  assert.equal((await call({ cookie: editorCookie })).status, 200);
+  name = (dbm.getDb().prepare('SELECT name FROM brands WHERE id = ?').get(BRAND_ID) as { name: string }).name;
+  assert.equal(name, 'RenamedBrand', 'editor rename should succeed');
+
+  assert.equal((await call({ cookie: adminCookie })).status, 200);
+});
+
+test('alerts POST/DELETE: viewer denied without changes; editor/admin allowed', async () => {
+  const postAlert = (headers: Record<string, string>) =>
+    alertsPost(req('http://localhost/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify({ name: 'rbac-alert' }),
+    }), ctx({ brandId: BRAND_ID }));
+
+  assert.equal((await postAlert({})).status, 401);
+  assert.equal((await postAlert({ cookie: viewerCookie })).status, 403);
+  assert.equal(count('brand_alerts'), 0, 'viewer must not create alerts');
+
+  const created = await postAlert({ cookie: editorCookie });
+  assert.equal(created.status, 201);
+  const alertId = (await created.json()).id as string;
+  assert.equal(count('brand_alerts'), 1);
+
+  assert.equal((await alertCheckPost(req('http://localhost/x', { method: 'POST', headers: { cookie: viewerCookie } }), ctx({ alertId }))).status, 403);
+  const checkRes = await alertCheckPost(req('http://localhost/x', { method: 'POST', headers: { cookie: editorCookie } }), ctx({ alertId }));
+  assert.equal(checkRes.status, 200);
+  assert.ok(typeof (await checkRes.json()).matched === 'number');
+
+  assert.equal((await alertDelete(req('http://localhost/x', { method: 'DELETE', headers: { cookie: viewerCookie } }), ctx({ alertId }))).status, 403);
+  assert.equal(count('brand_alerts'), 1, 'viewer must not delete alerts');
+
+  assert.equal((await alertDelete(req('http://localhost/x', { method: 'DELETE', headers: { cookie: editorCookie } }), ctx({ alertId }))).status, 200);
+  assert.equal(count('brand_alerts'), 0);
+});
+
+test('campaigns POST/DELETE: viewer denied; editor/admin allowed', async () => {
+  const postCampaign = (headers: Record<string, string>) =>
+    campaignsPost(req('http://localhost/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify({ name: 'rbac-campaign' }),
+    }), ctx({ brandId: BRAND_ID }));
+
+  assert.equal((await postCampaign({})).status, 401);
+  assert.equal((await postCampaign({ cookie: viewerCookie })).status, 403);
+  assert.equal(count('brand_campaigns'), 0);
+
+  const created = await postCampaign({ cookie: editorCookie });
+  assert.equal(created.status, 201);
+  const campaignId = (await created.json()).id as string;
+
+  assert.equal((await campaignDelete(req('http://localhost/x', { method: 'DELETE', headers: { cookie: viewerCookie } }), ctx({ campaignId }))).status, 403);
+  assert.equal(count('brand_campaigns'), 1);
+
+  assert.equal((await campaignDelete(req('http://localhost/x', { method: 'DELETE', headers: { cookie: editorCookie } }), ctx({ campaignId }))).status, 200);
+  assert.equal(count('brand_campaigns'), 0);
+});
+
+test('competitors POST/DELETE: viewer denied; editor allowed', async () => {
+  const postCompetitor = (headers: Record<string, string>) =>
+    competitorsPost(req('http://localhost/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify({ name: 'rbac-competitor' }),
+    }), ctx({ brandId: BRAND_ID }));
+
+  assert.equal((await postCompetitor({})).status, 401);
+  assert.equal((await postCompetitor({ cookie: viewerCookie })).status, 403);
+  assert.equal(count('brand_competitors'), 0);
+
+  const created = await postCompetitor({ cookie: editorCookie });
+  assert.equal(created.status, 201);
+  const competitorId = (await created.json()).id as string;
+
+  assert.equal((await competitorDelete(req('http://localhost/x', { method: 'DELETE', headers: { cookie: viewerCookie } }), ctx({ competitorId }))).status, 403);
+  assert.equal(count('brand_competitors'), 1);
+
+  assert.equal((await competitorDelete(req('http://localhost/x', { method: 'DELETE', headers: { cookie: editorCookie } }), ctx({ competitorId }))).status, 200);
+  assert.equal(count('brand_competitors'), 0);
+});
+
+test('digests POST: viewer denied; editor allowed', async () => {
+  const postDigest = (headers: Record<string, string>) =>
+    digestsPost(req('http://localhost/x', { method: 'POST', headers }), ctx({ brandId: BRAND_ID }));
+
+  assert.equal((await postDigest({})).status, 401);
+  assert.equal((await postDigest({ cookie: viewerCookie })).status, 403);
+
+  const res = await postDigest({ cookie: editorCookie });
+  assert.equal(res.status, 201);
+});
+
+test('mention PATCH: viewer denied without change; editor allowed', async () => {
+  const patch = (headers: Record<string, string>) =>
+    mentionPatch(req('http://localhost/x', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify({ sentiment: 'negative' }),
+    }), ctx({ mentionId: 'mention_rbac_test' }));
+
+  assert.equal((await patch({})).status, 401);
+
+  assert.equal((await patch({ cookie: viewerCookie })).status, 403);
+  let sentiment = (dbm.getDb().prepare('SELECT sentiment FROM brand_mentions WHERE id = ?').get('mention_rbac_test') as { sentiment: string }).sentiment;
+  assert.notEqual(sentiment, 'negative', 'viewer must not patch mentions');
+
+  assert.equal((await patch({ cookie: editorCookie })).status, 200);
+  sentiment = (dbm.getDb().prepare('SELECT sentiment FROM brand_mentions WHERE id = ?').get('mention_rbac_test') as { sentiment: string }).sentiment;
+  assert.equal(sentiment, 'negative');
+});
+
+test('mentions sync POST: viewer/editor denied before connector checks; authorized roles reach 412 preconditions', async () => {
+  const call = (headers: Record<string, string>) =>
+    mentionsSyncPost(req('http://localhost/x', { method: 'POST', headers }), ctx({ brandId: BRAND_ID }));
+
+  assert.equal((await call({})).status, 401);
+  assert.equal((await call({ cookie: viewerCookie })).status, 403);
+  assert.equal((await call({ cookie: editorCookie })).status, 412, 'editor passes auth and hits no-connector precondition');
+  assert.equal((await call({ cookie: adminCookie })).status, 412);
+});

--- a/src/lib/rbac-system-mutations.test.ts
+++ b/src/lib/rbac-system-mutations.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { NextRequest } from 'next/server';
+
+// NOTE: src/lib/db.ts captures its database path at module load, so every
+// module that reads process.env at load time (db, auth, sync) must be
+// dynamically imported inside before() AFTER the env vars below are set.
+const tempDir = mkdtempSync(path.join(tmpdir(), 'hermes-rbac-sys-test-'));
+const dbPath = path.join(tempDir, 'hermes-test.db');
+const openclawHome = path.join(tempDir, 'openclaw-home');
+const stateDir = path.join(tempDir, 'state');
+
+process.env.HERMES_DB_PATH = dbPath;
+process.env.AUTH_USER = 'admin_test';
+process.env.AUTH_PASS = 'super-secure-pass';
+process.env.API_KEY = 'test-api-key';
+process.env.HERMES_OPENCLAW_HOME = openclawHome;
+process.env.HERMES_STATE_DIR = stateDir;
+process.env.HERMES_ALLOW_POLICY_WRITE = 'true';
+
+type DbModule = typeof import('./db');
+type AuthModule = typeof import('./auth');
+type SyncModule = typeof import('./sync');
+let dbm: DbModule;
+let authm: AuthModule;
+let syncMod: SyncModule;
+let syncPost: typeof import('../app/api/sync/route')['POST'];
+let memoryPolicyPost: typeof import('../app/api/memory-policy/route')['POST'];
+let memoryAlertPolicyPost: typeof import('../app/api/memory-alert-policy/route')['POST'];
+let syncSessionsPost: typeof import('../app/api/chat/sync-sessions/route')['POST'];
+let outreachPausePost: typeof import('../app/api/outreach/pause/route')['POST'];
+
+const ADMIN = { 'x-api-key': 'test-api-key' };
+let viewerCookie: string;
+let editorCookie: string;
+
+type PostHandler = (req: never) => Promise<Response>;
+
+function post<H extends PostHandler>(handler: H, body?: unknown, headers: Record<string, string> = {}): Promise<Response> {
+  const req = new Request('http://localhost/test', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return handler(req as never);
+}
+
+// tsx emits CJS here, so dynamic imports wrap exports under `.default`.
+async function imp<T>(specifier: string): Promise<T> {
+  const m = (await import(specifier)) as { default?: T };
+  return (m.default ?? (m as unknown as T)) as T;
+}
+
+before(async () => {
+  dbm = await imp<typeof import('./db')>('./db');
+  authm = await imp<typeof import('./auth')>('./auth');
+  syncPost = (await imp<typeof import('../app/api/sync/route')>('../app/api/sync/route')).POST;
+  memoryPolicyPost = (await imp<typeof import('../app/api/memory-policy/route')>('../app/api/memory-policy/route')).POST;
+  memoryAlertPolicyPost = (await imp<typeof import('../app/api/memory-alert-policy/route')>('../app/api/memory-alert-policy/route')).POST;
+  syncSessionsPost = (await imp<typeof import('../app/api/chat/sync-sessions/route')>('../app/api/chat/sync-sessions/route')).POST;
+  outreachPausePost = (await imp<typeof import('../app/api/outreach/pause/route')>('../app/api/outreach/pause/route')).POST;
+  syncMod = await imp<typeof import('./sync')>('./sync');
+
+  authm.ensureAuthTables();
+  dbm.getDb().exec("DELETE FROM sessions; DELETE FROM users WHERE username IN ('rbac_viewer','rbac_editor');");
+  const viewer = authm.createUser('rbac_viewer', 'viewer-password-123', 'viewer');
+  viewerCookie = `hermes-session=${authm.createSession(viewer.id)}`;
+  const editor = authm.createUser('rbac_editor', 'editor-password-123', 'editor');
+  editorCookie = `hermes-session=${authm.createSession(editor.id)}`;
+});
+
+after(() => {
+  syncMod.stopSync();
+  dbm.resetDbForTests();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('POST /api/sync: unauthenticated 401, viewer 403, editor 403, admin allowed', async () => {
+  assert.equal((await post(syncPost)).status, 401);
+  assert.equal((await post(syncPost, undefined, { cookie: viewerCookie })).status, 403);
+  assert.equal((await post(syncPost, undefined, { cookie: editorCookie })).status, 403);
+
+  const res = await post(syncPost, undefined, ADMIN);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+});
+
+test('POST /api/memory-policy: viewer/editor denied before any file write; admin writes policy', async () => {
+  const policyFile = path.join(openclawHome, 'health', 'memory-policy.json');
+  const payload = { decay_half_life_days: 30 };
+
+  assert.equal((await post(memoryPolicyPost, payload)).status, 401);
+
+  const viewerRes = await post(memoryPolicyPost, payload, { cookie: viewerCookie });
+  assert.equal(viewerRes.status, 403);
+  assert.equal(existsSync(policyFile), false, 'policy file must not be created for viewer');
+
+  assert.equal((await post(memoryPolicyPost, payload, { cookie: editorCookie })).status, 403);
+  assert.equal(existsSync(policyFile), false, 'policy file must not be created for editor');
+
+  const adminRes = await post(memoryPolicyPost, payload, ADMIN);
+  assert.equal(adminRes.status, 200);
+  assert.equal((await adminRes.json()).ok, true);
+  assert.equal(existsSync(policyFile), true, 'policy file should exist after admin write');
+});
+
+test('POST /api/memory-alert-policy: viewer/editor denied; admin writes policy', async () => {
+  const policyFile = path.join(openclawHome, 'health', 'memory-alert-policy.json');
+  const payload = { window_days: 14 };
+
+  assert.equal((await post(memoryAlertPolicyPost, payload, { cookie: viewerCookie })).status, 403);
+  assert.equal((await post(memoryAlertPolicyPost, payload, { cookie: editorCookie })).status, 403);
+  assert.equal(existsSync(policyFile), false);
+
+  const adminRes = await post(memoryAlertPolicyPost, payload, ADMIN);
+  assert.equal(adminRes.status, 200);
+  assert.equal(existsSync(policyFile), true);
+});
+
+test('POST /api/chat/sync-sessions: viewer/editor denied without DB writes; admin allowed', async () => {
+  const countMessages = (): number =>
+    (dbm.getDb().prepare('SELECT COUNT(*) as c FROM messages').get() as { c: number }).c;
+
+  assert.equal((await post(syncSessionsPost)).status, 401);
+
+  const beforeCount = countMessages();
+  assert.equal((await post(syncSessionsPost, undefined, { cookie: viewerCookie })).status, 403);
+  assert.equal((await post(syncSessionsPost, undefined, { cookie: editorCookie })).status, 403);
+  assert.equal(countMessages(), beforeCount, 'no messages may be imported for denied roles');
+
+  const adminRes = await post(syncSessionsPost, undefined, ADMIN);
+  assert.equal(adminRes.status, 200);
+  const body = await adminRes.json();
+  assert.equal(body.imported, 0);
+});
+
+test('POST /api/outreach/pause: denial happens before flag/activity side effects', async () => {
+  const flagPath = path.join(stateDir, 'sending-paused.flag');
+  const activityCount = (): number =>
+    (dbm.getDb().prepare("SELECT COUNT(*) as c FROM activity_log WHERE action LIKE 'outreach_%'").get() as { c: number }).c;
+
+  const req = (body: unknown, headers: Record<string, string> = {}): NextRequest =>
+    new NextRequest(new URL('http://localhost/api/outreach/pause'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest;
+
+  assert.equal((await outreachPausePost(req({ paused: true }))).status, 401);
+
+  const beforeCount = activityCount();
+  assert.equal((await outreachPausePost(req({ paused: true }, { cookie: viewerCookie }))).status, 403);
+  assert.equal((await outreachPausePost(req({ paused: true }, { cookie: editorCookie }))).status, 403);
+  assert.equal(activityCount(), beforeCount, 'activity_log must be unchanged for denied roles');
+  assert.equal(existsSync(flagPath), false, 'pause flag must not be created for denied roles');
+
+  const adminRes = await outreachPausePost(req({ paused: true }, ADMIN));
+  assert.equal(adminRes.status, 200);
+  assert.equal((await adminRes.json()).paused, true);
+  assert.equal(existsSync(flagPath), true);
+
+  const resumeRes = await outreachPausePost(req({ paused: false }, ADMIN));
+  assert.equal(resumeRes.status, 200);
+  assert.equal(existsSync(flagPath), false);
+});


### PR DESCRIPTION
### Summary

A repo-wide audit of every API route handler found 16 mutation endpoints
that authenticated users but did not enforce a role/capability — any
authenticated **viewer** (read-only role) could trigger system-wide syncs,
rewrite memory-policy configuration, pause/resume global outreach sending,
import agent session transcripts, and create/delete brand data. One route
(`outreach/pause`) used only an inline auth-existence check.

### Changes

**Admin-level (`manage_system`) — was viewer-accessible:**

| Route | Was | Now |
|---|---|---|
| `POST /api/outreach/pause` | inline `getUserFromRequest` | `requireApiCapability('manage_system')` |
| `POST /api/sync` | `requireApiUser` | `requireApiCapability('manage_system')` |
| `POST /api/memory-policy` | `requireApiUser` | `requireApiCapability('manage_system')` |
| `POST /api/memory-alert-policy` | `requireApiUser` | `requireApiCapability('manage_system')` |
| `POST /api/chat/sync-sessions` | `requireApiUser` | `requireApiCapability('manage_system')` |

**Editor-level (`write_ops`) — was viewer-accessible:**
brand PATCH · alerts POST/DELETE/check · campaigns POST/DELETE ·
competitors POST/DELETE · digests POST · mention PATCH · mentions sync POST —
all moved from `requireApiUser` to `requireApiEditor`, matching the existing
editor convention (`crm`, `leads`, `content`, `sequences`, cron writes).

### Guarantees

- Authorization is now the **first statement** in every changed handler —
  before DB writes, filesystem writes, external API calls, and sync triggers.
- Existing helpers only (`requireApiCapability` / `requireApiEditor`); no new
  RBAC abstraction. Capability names come verbatim from `src/lib/rbac.ts`.
- Read endpoints intentionally unchanged (`sync GET` is dashboard bootstrap;
  `cron POST` is a deduplicated notification refresh) — rationale in PR notes.
- Feature gates (`HERMES_ALLOW_POLICY_WRITE`, `HERMES_ALLOW_CRON_WRITE`,
  `HERMES_ALLOW_WORKSPACE_WRITE`) retained as defense-in-depth after auth.

### Testing

Two new node:test suites (12 tests), using real session fixtures for all three roles:

- Full matrix per changed endpoint: unauthenticated → 401, viewer → 403,
  editor/admin → allowed (admin-only routes additionally prove editor → 403)
- Denials proven to occur **before side effects**: policy files not created,
  brand/alert/campaign/competitor rows and counts unchanged, `activity_log`
  unchanged, send-pause flag absent, no messages imported
- Positive paths verified end-to-end (policy file written, flag toggled+removed,
  rows created/deleted, rename persisted)
- `mentions/sync` uses its 412 "no connectors configured" precondition to prove
  authorization passes without calling external services

Results: `pnpm test` **38 pass / 0 fail** (3 consecutive runs);
eslint clean on changed files; `git diff --check` clean.

### Notes / follow-ups

- `pnpm run typecheck` fails only on the known pre-existing stale `.next`
  generated-types issue (removed `/agents` page) — unrelated.
- UI follow-ups surfaced by correct enforcement: chat view fires the now
  admin-only session-sync on mount for all users (silent 403), and settings
  exposes memory-policy editors to non-admins. Recommend gating those controls.
- Test-isolation hardening recommended separately: `src/lib/db.ts` captures
  its path at module load, so test files must dynamically import it after env
  setup (new suites do; older suites predate this).