### PR TITLE
fix: safely handle malformed applied_to JSON

### DIFF
--- a/src/app/experiments/page.tsx
+++ b/src/app/experiments/page.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { FlaskConical, Lightbulb } from 'lucide-react';
 import { useDashboard } from '@/store';
 import type { Experiment, Learning } from '@/types';
+import { parseAppliedTo } from '@/lib/experiments';
 
 type Tab = 'current' | 'history' | 'learnings';
 
@@ -94,7 +95,7 @@ export default function ExperimentsPage() {
                     {l.validated_week && <span>Week {l.validated_week}</span>}
                     {l.confidence && <Badge status={l.confidence} />}
                     {l.applied_to && (
-                      <span>Applied to: {JSON.parse(l.applied_to).join(', ')}</span>
+                      <span>Applied to: {parseAppliedTo(l.applied_to).join(', ')}</span>
                     )}
                   </div>
                 </div>

--- a/src/lib/experiments.test.ts
+++ b/src/lib/experiments.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { parseAppliedTo } from './experiments';
+
+test('parseAppliedTo parses valid JSON arrays', () => {
+  assert.deepEqual(
+    parseAppliedTo('["LinkedIn","X","YouTube"]'),
+    ['LinkedIn', 'X', 'YouTube'],
+  );
+});
+
+test('parseAppliedTo returns empty array for malformed JSON', () => {
+  assert.deepEqual(
+    parseAppliedTo('["LinkedIn",INVALID]'),
+    [],
+  );
+});
+
+test('parseAppliedTo returns empty array for non-array JSON', () => {
+  assert.deepEqual(
+    parseAppliedTo('{"platform":"LinkedIn"}'),
+    [],
+  );
+});
+
+test('parseAppliedTo returns empty array for non-string array values', () => {
+  assert.deepEqual(
+    parseAppliedTo('[1,2,3]'),
+    [],
+  );
+});
+
+test('parseAppliedTo returns empty array for null or empty values', () => {
+  assert.deepEqual(parseAppliedTo(null), []);
+  assert.deepEqual(parseAppliedTo(''), []);
+});

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -1,0 +1,17 @@
+export function parseAppliedTo(value: string | null): string[] {
+  if (!value) return [];
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+
+    if (!Array.isArray(parsed) || !parsed.every(item => typeof item === 'string')) {
+      console.warn('[experiments] Invalid applied_to data');
+      return [];
+    }
+
+    return parsed;
+  } catch {
+    console.warn('[experiments] Failed to parse applied_to data');
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

Fixes Issue #38 by safely handling malformed `applied_to` JSON data on the Experiments page.

Previously, `JSON.parse()` was called directly during rendering. If a database record contained malformed or unexpected JSON, the Experiments page could crash.

## Changes

- Added `parseAppliedTo()` helper to safely parse `applied_to` values.
- Handles malformed JSON without crashing the page.
- Validates that parsed data is an array of strings.
- Returns an empty array for invalid, malformed, or empty values.
- Updated the Experiments page to use the safe parser.
- Added regression tests covering valid JSON, malformed JSON, non-array JSON, non-string values, and null/empty values.

## Testing

- `pnpm exec eslint src/app/experiments/page.tsx src/lib/experiments.ts src/lib/experiments.test.ts` — passed
- `pnpm test` — 62 tests passed, 0 failed

Note: GitHub CI currently reports pre-existing lint errors in `src/app/page.tsx` unrelated to this PR.

## Related Issue

Closes #38