### PR TITLE
fix: serialize concurrent cron mutations

### DIFF
--- a/src/app/api/cron/jobs/route.ts
+++ b/src/app/api/cron/jobs/route.ts
@@ -5,10 +5,10 @@ import { logAudit } from '@/lib/audit';
 import { allowCronWrite, getInstance, resolveOpenClawPaths } from '@/lib/instances';
 import {
   deleteCronJob,
+  mutateCronJobsFile,
   normalizeJobId,
   readCronJobsFile,
   upsertCronJob,
-  writeCronJobsFile,
   type CronJobConfig,
 } from '@/lib/cron-jobs';
 
@@ -61,12 +61,17 @@ export async function POST(req: NextRequest) {
   try {
     const instance = getInstance(getInstanceId(req));
     const { cronDir } = resolveOpenClawPaths(instance);
-    const jobsFile = await readCronJobsFile(cronDir);
-    if (jobsFile.jobs.some((j) => normalizeJobId(j.id ?? j.jobId) === id)) {
-      return NextResponse.json({ error: 'Job already exists' }, { status: 409 });
-    }
-    const next = upsertCronJob(jobsFile, { ...(job || {}), id, jobId: id });
-    await writeCronJobsFile(cronDir, next);
+    const next = await mutateCronJobsFile(cronDir, (jobsFile) => {
+  if (jobsFile.jobs.some((j) => normalizeJobId(j.id ?? j.jobId) === id)) {
+    return null;
+  }
+
+    return upsertCronJob(jobsFile, { ...(job || {}), id, jobId: id });
+});
+
+  if (!next) {
+    return NextResponse.json({ error: 'Job already exists' }, { status: 409 });
+  }
 
     logAudit({
       actor,
@@ -98,12 +103,17 @@ export async function PATCH(req: NextRequest) {
   try {
     const instance = getInstance(getInstanceId(req));
     const { cronDir } = resolveOpenClawPaths(instance);
-    const jobsFile = await readCronJobsFile(cronDir);
-    if (!jobsFile.jobs.some((j) => normalizeJobId(j.id ?? j.jobId) === id)) {
-      return NextResponse.json({ error: 'Not found' }, { status: 404 });
-    }
-    const next = upsertCronJob(jobsFile, { ...(job || {}), id, jobId: id });
-    await writeCronJobsFile(cronDir, next);
+    const next = await mutateCronJobsFile(cronDir, (jobsFile) => {
+  if (!jobsFile.jobs.some((j) => normalizeJobId(j.id ?? j.jobId) === id)) {
+    return null;
+  }
+
+    return upsertCronJob(jobsFile, { ...(job || {}), id, jobId: id });
+});
+
+  if (!next) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
 
     logAudit({
       actor,
@@ -132,12 +142,17 @@ export async function DELETE(req: NextRequest) {
   try {
     const instance = getInstance(getInstanceId(req));
     const { cronDir } = resolveOpenClawPaths(instance);
-    const jobsFile = await readCronJobsFile(cronDir);
-    if (!jobsFile.jobs.some((j) => normalizeJobId(j.id ?? j.jobId) === id)) {
-      return NextResponse.json({ error: 'Not found' }, { status: 404 });
-    }
-    const next = deleteCronJob(jobsFile, id);
-    await writeCronJobsFile(cronDir, next);
+    const next = await mutateCronJobsFile(cronDir, (jobsFile) => {
+  if (!jobsFile.jobs.some((j) => normalizeJobId(j.id ?? j.jobId) === id)) {
+    return null;
+  }
+
+    return deleteCronJob(jobsFile, id);
+});
+
+  if (!next) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
 
     logAudit({
       actor,

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -8,11 +8,11 @@ import { requireUser } from '@/lib/auth';
 import { logAudit } from '@/lib/audit';
 import { allowCronWrite, getInstance, resolveOpenClawPaths } from '@/lib/instances';
 import {
+  mutateCronJobsFile,
   normalizeJobId,
   readCronJobsFile,
   toggleCronJob,
   triggerCronJobNow,
-  writeCronJobsFile,
   type CronJobConfig,
 } from '@/lib/cron-jobs';
 
@@ -158,14 +158,15 @@ export async function PUT(request: Request) {
   try {
     const instance = getInstance(getInstanceId(request));
     const { cronDir } = resolveOpenClawPaths(instance);
-    const jobsFile = await readCronJobsFile(cronDir);
-    const next =
-      action === 'toggle'
-        ? toggleCronJob(jobsFile, id)
-        : triggerCronJobNow(jobsFile, id);
+    const next = await mutateCronJobsFile(cronDir, (jobsFile) =>
+    action === 'toggle'
+    ? toggleCronJob(jobsFile, id)
+    : triggerCronJobNow(jobsFile, id),
+    );
 
-    if (!next) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-    await writeCronJobsFile(cronDir, next);
+  if (!next) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
 
     logAudit({
       actor,

--- a/src/lib/cron-jobs.test.ts
+++ b/src/lib/cron-jobs.test.ts
@@ -12,6 +12,7 @@ import {
   triggerCronJobNow,
   upsertCronJob,
   writeCronJobsFile,
+  mutateCronJobsFile,
 } from './cron-jobs';
 
 const tempDir = mkdtempSync(path.join(tmpdir(), 'hermes-cron-jobs-test-'));
@@ -146,4 +147,38 @@ test('cron schedule and delivery fields are preserved for OpenClaw compatibility
   assert.ok(job);
   assert.equal((job.schedule as Record<string, unknown>)?.staggerMs, 15_000);
   assert.equal((job.delivery as Record<string, unknown>)?.mode, 'session_message');
+});
+
+test('mutateCronJobsFile serializes concurrent mutations', async () => {
+  const cronDir = path.join(tempDir, 'cron-concurrent');
+  await fs.mkdir(cronDir, { recursive: true });
+
+  await fs.writeFile(
+    path.join(cronDir, 'jobs.json'),
+    JSON.stringify({ version: 1, jobs: [] }, null, 2),
+    'utf-8',
+  );
+
+  const results = await Promise.all([
+    mutateCronJobsFile(cronDir, (jobsFile) =>
+      upsertCronJob(jobsFile, {
+        id: 'concurrent-a',
+        enabled: true,
+      }),
+    ),
+    mutateCronJobsFile(cronDir, (jobsFile) =>
+      upsertCronJob(jobsFile, {
+        id: 'concurrent-b',
+        enabled: true,
+      }),
+    ),
+  ]);
+
+  assert.ok(results[0]);
+  assert.ok(results[1]);
+
+  const final = await readCronJobsFile(cronDir);
+  const ids = final.jobs.map((job) => job.id);
+
+  assert.deepEqual(ids.sort(), ['concurrent-a', 'concurrent-b']);
 });

--- a/src/lib/cron-jobs.ts
+++ b/src/lib/cron-jobs.ts
@@ -92,10 +92,51 @@ export async function readCronJobsFile(cronDir: string): Promise<CronJobsFile> {
   return { version: 1, jobs: [] };
 }
 
+type CronMutation = (jobsFile: CronJobsFile) => CronJobsFile | null;
+
+const cronMutationLocks = new Map<string, Promise<void>>();
+
+export async function mutateCronJobsFile(
+  cronDir: string,
+  mutation: CronMutation,
+): Promise<CronJobsFile | null> {
+  const previous = cronMutationLocks.get(cronDir) ?? Promise.resolve();
+
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  const queued = previous.then(() => current);
+  cronMutationLocks.set(cronDir, queued);
+
+  await previous;
+
+  try {
+    const jobsFile = await readCronJobsFile(cronDir);
+    const next = mutation(jobsFile);
+
+    if (next) {
+      await writeCronJobsFile(cronDir, next);
+    }
+
+    return next;
+  } finally {
+    release();
+
+    if (cronMutationLocks.get(cronDir) === queued) {
+      cronMutationLocks.delete(cronDir);
+    }
+  }
+}
+
 async function writeJsonAtomic(filePath: string, data: unknown): Promise<void> {
   const dir = path.dirname(filePath);
   const base = path.basename(filePath);
-  const tmp = path.join(dir, `.${base}.tmp.${Date.now()}`);
+  const tmp = path.join(
+  dir,
+  `.${base}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}`,
+);
   await fs.writeFile(tmp, JSON.stringify(data, null, 2) + '\n', 'utf-8');
   await fs.rename(tmp, filePath);
 }


### PR DESCRIPTION
## Summary

Fixes Issue #40 by preventing concurrent cron mutations from overwriting each other's changes.

Previously, concurrent cron API mutations could perform a read-modify-write sequence at the same time, causing one mutation to overwrite another.

## Changes

- Added `mutateCronJobsFile()` to serialize cron file mutations per cron directory.
- Updated cron job create, update, and delete APIs to use the serialized mutation helper.
- Updated cron toggle and trigger-now operations to use the same mutation mechanism.
- Added unique temporary filenames for atomic JSON writes.
- Added a regression test covering concurrent cron mutations.

## Testing

- ESLint passed for all changed files.
- `pnpm test` — 58 tests passed, 0 failed.
- `git diff  --check` — passed.

## Related Issue

Closes #40