### PR TITLE
fix: correct approvals history event types

### DIFF
--- a/src/app/api/approvals/history/route.ts
+++ b/src/app/api/approvals/history/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: Request) {
     const rows = db.prepare(
       `SELECT id, ts, action, detail, result
        FROM activity_log
-       WHERE action IN ('content_approved', 'content_rejected', 'sequence_approved', 'sequence_rejected')
+       WHERE action IN ('approve', 'reject')
        ORDER BY ts DESC
        LIMIT 50`
     ).all();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -383,7 +383,7 @@ export default function OverviewPage() {
                   <SnapshotRow label="Engagement" value={metricsReversed[metricsReversed.length - 1]?.total_engagement ?? 0} color="bg-success" />
                   <SnapshotRow label="Sends" value={metricsReversed[metricsReversed.length - 1]?.sends ?? 0} color="bg-warning" />
                   <p className="text-xs text-muted-foreground pt-2">
-                    Trends update as campaigns and agents record activity. Switch to "Real" data in the header to exclude seeded samples.
+                    Trends update as campaigns and agents record activity. Switch to &quot;Real&quot; data in the header to exclude seeded samples.
                   </p>
                 </div>
               ) : (


### PR DESCRIPTION
## Summary

Fixes Issue #39 by correcting the approval history event filter.

The approval API records `approve` and `reject` actions in `activity_log`, while the approval history endpoint was incorrectly filtering for `content_approved`, `content_rejected`, `sequence_approved`, and `sequence_rejected`.

## Changes

- Updated the approval history query to use the actual `approve` and `reject` activity actions.
- Preserved the existing history ordering and limit.
- Removed the mismatch between approval events and history filtering.

## Testing

- `pnpm exec eslint src/app/api/approvals/history/route.ts` — passed
- `pnpm test` — 57 tests passed, 0 failed
- `git diff --check` — passed

## Related Issue

Closes #39