### PR TITLE
Fix set-state-in-effect lint errors

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -383,7 +383,7 @@ export default function OverviewPage() {
                   <SnapshotRow label="Engagement" value={metricsReversed[metricsReversed.length - 1]?.total_engagement ?? 0} color="bg-success" />
                   <SnapshotRow label="Sends" value={metricsReversed[metricsReversed.length - 1]?.sends ?? 0} color="bg-warning" />
                   <p className="text-xs text-muted-foreground pt-2">
-                    Trends update as campaigns and agents record activity. Switch to "Real" data in the header to exclude seeded samples.
+                    Trends update as campaigns and agents record activity. Switch to &quot;Real&quot; data in the header to exclude seeded samples.
                   </p>
                 </div>
               ) : (

--- a/src/components/brand/brand-header.tsx
+++ b/src/components/brand/brand-header.tsx
@@ -31,7 +31,33 @@ export function BrandHeader({ brandId, title }: { brandId: string; title: string
   }
 
   useEffect(() => {
-    loadBrand();
+  let cancelled = false;
+
+  fetch(`/api/brand/${brandId}`)
+    .then(async res => {
+      const data = await res.json();
+
+      if (!res.ok || data.error) {
+        throw new Error(data.error || 'Brand not found');
+      }
+
+      if (!cancelled) {
+        setBrand(data);
+        setError(null);
+        setLoading(false);
+      }
+    })
+    .catch(err => {
+      if (!cancelled) {
+        setBrand(null);
+        setError((err as Error).message || 'Brand not found');
+        setLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [brandId]);
 
   if (loading) {

--- a/src/components/brand/tabs/analytics-tab.tsx
+++ b/src/components/brand/tabs/analytics-tab.tsx
@@ -28,29 +28,62 @@ export function AnalyticsTab({ brandId, realOnly }: { brandId: string; realOnly:
   }, [brandId]);
 
   const loadAll = useCallback(() => {
-    setLoading(true);
-    setError(null);
-    const real = realOnly ? '?real=true' : '';
-    Promise.all([
-      fetch(`/api/brand/${brandId}/stats${real}`).then(r => {
-        if (!r.ok) throw new Error('Failed to load brand statistics');
-        return r.json();
-      }),
-      fetch(`/api/brand/${brandId}/creators${real}`).then(r => r.json()).catch(() => []),
-      fetch(`/api/brand/${brandId}/competitors`).then(r => r.json()).catch(() => []),
-    ])
-      .then(([statsData, creatorsData, competitorsData]) => {
-        setStats(statsData);
-        setCreators(Array.isArray(creatorsData) ? creatorsData : []);
-        setCompetitors(Array.isArray(competitorsData) ? competitorsData : []);
-      })
-      .catch(err => setError((err as Error).message || 'Failed to load brand analytics'))
-      .finally(() => setLoading(false));
-  }, [brandId, realOnly]);
+  setLoading(true);
+  setError(null);
+  const real = realOnly ? '?real=true' : '';
 
-  useEffect(() => {
-    loadAll();
-  }, [loadAll]);
+  Promise.all([
+    fetch(`/api/brand/${brandId}/stats${real}`).then(r => {
+      if (!r.ok) throw new Error('Failed to load brand statistics');
+      return r.json();
+    }),
+    fetch(`/api/brand/${brandId}/creators${real}`).then(r => r.json()).catch(() => []),
+    fetch(`/api/brand/${brandId}/competitors`).then(r => r.json()).catch(() => []),
+  ])
+    .then(([statsData, creatorsData, competitorsData]) => {
+      setStats(statsData);
+      setCreators(Array.isArray(creatorsData) ? creatorsData : []);
+      setCompetitors(Array.isArray(competitorsData) ? competitorsData : []);
+    })
+    .catch(err => setError((err as Error).message || 'Failed to load brand analytics'))
+    .finally(() => setLoading(false));
+}, [brandId, realOnly]);
+
+useEffect(() => {
+  let cancelled = false;
+
+  const real = realOnly ? '?real=true' : '';
+
+  Promise.all([
+    fetch(`/api/brand/${brandId}/stats${real}`).then(r => {
+      if (!r.ok) throw new Error('Failed to load brand statistics');
+      return r.json();
+    }),
+    fetch(`/api/brand/${brandId}/creators${real}`).then(r => r.json()).catch(() => []),
+    fetch(`/api/brand/${brandId}/competitors`).then(r => r.json()).catch(() => []),
+  ])
+    .then(([statsData, creatorsData, competitorsData]) => {
+      if (cancelled) return;
+
+      setStats(statsData);
+      setCreators(Array.isArray(creatorsData) ? creatorsData : []);
+      setCompetitors(Array.isArray(competitorsData) ? competitorsData : []);
+    })
+    .catch(err => {
+      if (!cancelled) {
+        setError((err as Error).message || 'Failed to load brand analytics');
+      }
+    })
+    .finally(() => {
+      if (!cancelled) {
+        setLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [brandId, realOnly]);
 
   async function addCompetitor(e: React.FormEvent) {
     e.preventDefault();

--- a/src/components/brand/tabs/overview-tab.tsx
+++ b/src/components/brand/tabs/overview-tab.tsx
@@ -40,8 +40,41 @@ export function OverviewTab({ brandId, realOnly }: { brandId: string; realOnly: 
   }, [brandId, realOnly]);
 
   useEffect(() => {
-    loadData();
-  }, [loadData]);
+  let cancelled = false;
+
+  const real = realOnly ? '?real=true' : '';
+
+  Promise.all([
+    fetch(`/api/brand/${brandId}/stats${real}`).then(r => {
+      if (!r.ok) throw new Error('Failed to load brand metrics');
+      return r.json();
+    }),
+    fetch(`/api/brand/${brandId}/mentions?sort=popular${real ? '&real=true' : ''}`).then(r => {
+      if (!r.ok) throw new Error('Failed to load brand mentions');
+      return r.json();
+    }),
+  ])
+    .then(([statsData, mentionsData]: [BrandMentionStats, BrandMention[]]) => {
+      if (cancelled) return;
+
+      setStats(statsData);
+      setMentions(Array.isArray(mentionsData) ? mentionsData.slice(0, 6) : []);
+    })
+    .catch(err => {
+      if (!cancelled) {
+        setError((err as Error).message || 'Failed to load brand overview.');
+      }
+    })
+    .finally(() => {
+      if (!cancelled) {
+        setLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [brandId, realOnly]);
 
   function onPatch(id: string, patch: Record<string, string>) {
     setMentions(prev => prev.map(m => (m.id === id ? { ...m, ...patch } as BrandMention : m)));


### PR DESCRIPTION
## Summary
- Fix React set-state-in-effect lint errors in brand components
- Refactor brand header data loading to avoid synchronous state updates inside effects
- Update analytics and overview data-loading effects

## Validation
- ESLint passes for the modified brand components
- Full ESLint now has no set-state-in-effect errors

Closes #48