### PR TITLE
Refetch data when approval and CRM filters change

### DIFF
--- a/src/app/approvals/page.tsx
+++ b/src/app/approvals/page.tsx
@@ -61,7 +61,7 @@ export default function ApprovalsPage() {
 
   const { data, refetch } = useSmartPoll<ApprovalData>(
     () => fetch(`/api/approvals${realParam}`).then(r => r.json()),
-    { interval: 30_000 },
+    { interval: 30_000, key: realOnly },
   );
 
   const { data: historyData } = useSmartPoll<{ history: ApprovalHistory[] }>(

--- a/src/app/crm/page.tsx
+++ b/src/app/crm/page.tsx
@@ -183,7 +183,10 @@ export default function CrmPage() {
 
   const { data } = useSmartPoll<CrmData>(
     () => fetch(`/api/crm?${params}`).then(r => r.json()),
-    { interval: 30_000, key: `${realOnly}-${refreshKey}` },
+    {
+      interval: 30_000,
+      key: `${realOnly}-${stageFilter}-${tierFilter}-${search}-${refreshKey}`,
+    },
   );
 
   const leads = data?.leads || [];


### PR DESCRIPTION
## Summary

- Fix stale CRM and Approvals data when filters change.
- Trigger an immediate refetch when filter state changes instead of waiting for the next polling interval.
- Extend `useSmartPoll` key dependencies to include the active filter values.

## Changes

- Approvals:
  - Added `realOnly` as the polling key.
  - Changing the Real/All filter now triggers an immediate refetch.

- CRM:
  - Added `realOnly`, `stageFilter`, `tierFilter`, `search`, and `refreshKey` to the polling key.
  - Changing CRM filters now immediately fetches data matching the new filter state.

## Validation

- [x] `pnpm exec eslint src/app/approvals/page.tsx src/app/crm/page.tsx`
- [x] `git diff --check`
- [x] Changes committed and pushed successfully

Closes #70